### PR TITLE
add arg for `localnet` cmd to allow for bpf loaded programs

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::parser::ProgramInfo;
 use clap::{Arg, ArgGroup, Command};
 use clockwork_client::http::state::HttpMethod;
 use solana_sdk::{pubkey::Pubkey, signature::Keypair};
@@ -33,7 +34,9 @@ pub enum CliCommand {
     },
 
     // Localnet commands
-    Localnet,
+    Localnet {
+        program_infos: Vec<ProgramInfo>,
+    },
 
     // Node commands
     NodeGet {
@@ -193,7 +196,20 @@ pub fn app() -> Command<'static> {
         )
         .subcommand(
             Command::new("localnet")
-                .about("Launch a local Clockwork node for development and testing"),
+                .about("Launch a local Clockwork node for development and testing")
+                .arg(
+                    Arg::with_name("bpf_program")
+                        .long("bpf-program")
+                        .value_names(&["ADDRESS_OR_KEYPAIR", "BPF_PROGRAM.SO"])
+                        .takes_value(true)
+                        .number_of_values(2)
+                        .multiple(true)
+                        .help(
+                            "Add a BPF program to the genesis configuration. \
+                       If the ledger already exists then this parameter is silently ignored. \
+                       First argument can be a pubkey string or path to a keypair",
+                        ),
+                ),
         )
         .subcommand(
             Command::new("node")

--- a/cli/src/errors.rs
+++ b/cli/src/errors.rs
@@ -18,4 +18,8 @@ pub enum CliError {
     FailedTransaction(String),
     #[error("Failed to start localnet with error: {0}")]
     FailedLocalnet(String),
+    #[error("Invalid address")]
+    InvalidAddress,
+    #[error("Program file does not exist")]
+    InvalidProgramFile,
 }

--- a/cli/src/processor/process.rs
+++ b/cli/src/processor/process.rs
@@ -32,7 +32,7 @@ pub fn process(matches: &ArgMatches) -> Result<(), CliError> {
             route,
         } => super::http::request_new(&client, api, id, method, route),
         CliCommand::Initialize { mint } => super::initialize::initialize(&client, mint),
-        CliCommand::Localnet {} => super::localnet::start(&client),
+        CliCommand::Localnet { program_infos } => super::localnet::start(&client, program_infos),
         CliCommand::NodeGet { worker } => super::node::get_by_worker(&client, worker),
         CliCommand::NodeRegister { worker } => super::node::register(&client, worker),
         CliCommand::NodeStake { amount, worker } => super::node::stake(&client, amount, worker),


### PR DESCRIPTION
- adds the use of the `--bpf-program` flag to allow for bpf loaded programs when running `clockwork localnet`