### PR TITLE
consolidate programs and client into sdk package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,6 +910,11 @@ version = "1.0.6"
 dependencies = [
  "chrono",
  "chrono-tz",
+ "clockwork-client",
+ "clockwork-crank",
+ "clockwork-http",
+ "clockwork-network",
+ "clockwork-pool",
  "nom",
  "once_cell",
 ]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -14,9 +14,22 @@ keywords = ["solana"]
 name = "clockwork_sdk"
 
 [dependencies]
+clockwork-crank = { path = "../programs/crank", features = ["cpi"], version = "1.0.6", optional = true }
+clockwork-http = { path = "../programs/http", features = ["cpi"],version = "1.0.6", optional = true }
+clockwork-network = { path = "../programs/network", features = ["cpi"], version = "1.0.6", optional = true }
+clockwork-pool = { path = "../programs/pool", features = ["cpi"], version = "1.0.6", optional = true }
+clockwork-client = { path = "../client", version = "1.0.6", optional = true }
 chrono = { version = "0.4.19", default-features = false, features = ["alloc"] }
 nom = "~7"
 once_cell = "1.5.2"
 
 [dev-dependencies]
 chrono-tz = "0.6.1"
+
+[features]
+default = ["crank", "http", "client"]
+crank = ["clockwork-crank"]
+http = ["clockwork-http"]
+network = ["clockwork-network"]
+pool = ["clockwork-pool"]
+client = ["clockwork-client"]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -61,13 +61,5 @@ pub mod program {
 
 #[cfg(feature = "client")]
 pub mod client {
-    #[cfg(feature = "crank")]
-    pub use clockwork_client::crank::*;
-    #[cfg(feature = "http")]
-    pub use clockwork_client::http::*;
-    #[cfg(feature = "network")]
-    pub use clockwork_client::network::*;
-    #[cfg(feature = "pool")]
-    pub use clockwork_client::pool::*;
-    pub use clockwork_client::Client;
+    pub use clockwork_client::*;
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,0 +1,73 @@
+#[cfg(feature = "crank")]
+pub use clockwork_crank::state::{
+    AccountMetaData, ClockData, Config as CrankConfig, ConfigAccount as CrankConfigAccount,
+    ConfigSettings as CrankConfigSettings, CrankResponse, ExecContext, Fee, FeeAccount,
+    InstructionData, Queue, QueueAccount, Trigger, TriggerContext,
+    SEED_CONFIG as SEED_CRANK_CONFIG, SEED_FEE, SEED_QUEUE,
+};
+
+#[cfg(feature = "http")]
+pub use clockwork_http::state::{
+    Api, ApiAccount, Config as HttpConfig, ConfigAccount as HttpConfigAccount,
+    ConfigSettings as HttpConfigSettings, HttpMethod, Request, RequestAccount, SEED_API,
+    SEED_CONFIG as SEED_HTTP_CONFIG, SEED_REQUEST,
+};
+
+#[cfg(feature = "network")]
+pub use clockwork_network::state::{
+    Authority, Config as NetworkConfig, ConfigAccount as NetworkConfigAccount,
+    ConfigSettings as NetworkConfigSettings, Node, NodeAccount, NodeSettings, Registry,
+    RegistryAccount, Rotator, RotatorAccount, Snapshot, SnapshotAccount, SnapshotEntry,
+    SnapshotEntryAccount, SnapshotStatus, SEED_AUTHORITY, SEED_CONFIG as SEED_NETWORK_CONFIG,
+    SEED_NODE, SEED_REGISTRY, SEED_ROTATOR, SEED_SNAPSHOT, SEED_SNAPSHOT_ENTRY,
+};
+
+#[cfg(feature = "pool")]
+pub use clockwork_pool::state::{
+    Config as PoolConfig, ConfigAccount as PoolConfigAccount, ConfigSettings as PoolConfigSettings,
+    Pool, PoolAccount, PoolSettings, SEED_CONFIG as SEED_POOL_CONFIG, SEED_POOL,
+};
+
+pub mod program {
+    #[cfg(feature = "crank")]
+    pub mod crank {
+        pub use clockwork_crank::{
+            accounts::*, anchor::*, clockwork_crank::*, cpi::*, entry, errors::*, errors::*, id::*,
+            instruction::*, payer::*, program::ClockworkCrank,
+        };
+    }
+    #[cfg(feature = "http")]
+    pub mod http {
+        pub use clockwork_http::{
+            accounts::*, clockwork_http::*, cpi::*, entry, errors::*, errors::*, id::*,
+            instruction::*, program::ClockworkHttp,
+        };
+    }
+    #[cfg(feature = "network")]
+    pub mod network {
+        pub use clockwork_network::{
+            accounts::*, clockwork_network::*, cpi::*, entry, errors::*, errors::*, id::*,
+            instruction::*, program::ClockworkNetwork,
+        };
+    }
+    #[cfg(feature = "pool")]
+    pub mod pool {
+        pub use clockwork_pool::{
+            accounts::*, clockwork_pool::*, cpi::*, entry, errors::*, errors::*, id::*,
+            instruction::*, program::ClockworkPool,
+        };
+    }
+}
+
+#[cfg(feature = "client")]
+pub mod client {
+    #[cfg(feature = "crank")]
+    pub use clockwork_client::crank::*;
+    #[cfg(feature = "http")]
+    pub use clockwork_client::http::*;
+    #[cfg(feature = "network")]
+    pub use clockwork_client::network::*;
+    #[cfg(feature = "pool")]
+    pub use clockwork_client::pool::*;
+    pub use clockwork_client::Client;
+}


### PR DESCRIPTION
- flatten state for all programs to be accessed from the root module of `clockwork_sdk` like:
 ```rust 
clockwork_sdk::Queue::pda()
clockwork_sdk::Pool
 ```
- add feature flags `crank`, `http`, `network`, `pool`, and `client`
- default flags are `crank`, `http`, and `client`
- respective non-state modules can be accessed like:
 ```rust 
clockwork_sdk::program::crank::cpi::queue_create(
  ...
);
 ```
