### PR TITLE
Introduce `TriggerType::Account` to allow for triggering queues when an account's data has changed

### DIFF
--- a/client/src/crank/instruction/queue_crank.rs
+++ b/client/src/crank/instruction/queue_crank.rs
@@ -10,7 +10,7 @@ use {
     clockwork_pool::state::Pool,
 };
 
-pub fn queue_crank(queue: Pubkey, worker: Pubkey) -> Instruction {
+pub fn queue_crank(data_hash: Option<u64>, queue: Pubkey, worker: Pubkey) -> Instruction {
     Instruction {
         program_id: clockwork_crank::ID,
         accounts: vec![
@@ -21,6 +21,6 @@ pub fn queue_crank(queue: Pubkey, worker: Pubkey) -> Instruction {
             AccountMeta::new(system_program::ID, false),
             AccountMeta::new(worker, true),
         ],
-        data: clockwork_crank::instruction::QueueCrank {}.data(),
+        data: clockwork_crank::instruction::QueueCrank { data_hash }.data(),
     }
 }

--- a/plugin/src/plugin.rs
+++ b/plugin/src/plugin.rs
@@ -63,7 +63,13 @@ impl GeyserPlugin for ClockworkPlugin {
         };
         let account_pubkey = Pubkey::new(account_info.clone().pubkey);
 
-        // Parse and process the account update
+        // Send all account updates to the queue observer for account listeners.
+        self.observers
+            .queue
+            .clone()
+            .handle_updated_account(account_pubkey, account_info.clone())?;
+
+        // Parse and process specific update events.
         match AccountUpdateEvent::try_from(account_info) {
             Ok(event) => match event {
                 AccountUpdateEvent::Clock { clock } => {

--- a/programs/crank/src/instructions/queue_resume.rs
+++ b/programs/crank/src/instructions/queue_resume.rs
@@ -33,6 +33,9 @@ pub fn handler(ctx: Context<QueueResume>) -> Result<()> {
         None => {}
         Some(exec_context) => {
             match exec_context {
+                ExecContext::Account { data_hash: _ } => {
+                    // Nothing to do
+                }
                 ExecContext::Cron { started_at: _ } => {
                     // Jump ahead to the current timestamp
                     queue.exec_context = Some(ExecContext::Cron { started_at: Clock::get().unwrap().unix_timestamp });

--- a/programs/crank/src/lib.rs
+++ b/programs/crank/src/lib.rs
@@ -24,8 +24,8 @@ pub mod clockwork_crank {
         initialize::handler(ctx, worker_pool)
     }
 
-    pub fn queue_crank(ctx: Context<QueueCrank>) -> Result<()> {
-        queue_crank::handler(ctx)
+    pub fn queue_crank(ctx: Context<QueueCrank>, data_hash: Option<u64>) -> Result<()> {
+        queue_crank::handler(ctx, data_hash)
     }
 
     pub fn queue_create(

--- a/programs/crank/src/state/queue.rs
+++ b/programs/crank/src/state/queue.rs
@@ -211,6 +211,7 @@ impl Default for CrankResponse {
 
 #[derive(AnchorDeserialize, AnchorSerialize, Debug, Clone)]
 pub enum Trigger {
+    Account { pubkey: Pubkey },
     Cron { schedule: String },
     Immediate,
 }
@@ -221,6 +222,7 @@ pub enum Trigger {
 
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub enum ExecContext {
+    Account { data_hash: u64 },
     Cron { started_at: i64 },
     Immediate,
 }


### PR DESCRIPTION
This is useful for event-driven or oracle-driven queues. 