### PR TITLE
Re-export program state under the 'accounts' mod

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -3,9 +3,11 @@
  */
 
 pub mod queue_program {
-    pub use clockwork_queue_program::{
-        accounts, cpi, errors, program::QueueProgram, state, utils, ID,
-    };
+    pub use clockwork_queue_program::{cpi, errors, program::QueueProgram, utils, ID};
+    pub mod accounts {
+        pub use clockwork_queue_program::accounts::*;
+        pub use clockwork_queue_program::state::*;
+    }
 }
 
 /**


### PR DESCRIPTION
Unifies the `state` and `accounts` mods into a single `accounts` mod under `clockwork_sdk::queue_program::`.