### PR TITLE
Use seeds/bumps for account verification where needed

### DIFF
--- a/cli/src/processor/initialize.rs
+++ b/cli/src/processor/initialize.rs
@@ -5,7 +5,7 @@ use {
 };
 
 pub fn initialize(client: &Client, mint: Pubkey) -> Result<(), CliError> {
-    // TODO Create a worker pool
+    // Create a worker pool
     let pool_name = "crank";
     let pool = Pool::pubkey(pool_name.into());
 

--- a/programs/network/src/instructions/entry_create.rs
+++ b/programs/network/src/instructions/entry_create.rs
@@ -19,7 +19,12 @@ pub struct EntryCreate<'info> {
 
     #[account(
         init,
-        address = SnapshotEntry::pubkey(snapshot.key(), snapshot.node_count),
+        seeds = [
+            SEED_SNAPSHOT_ENTRY,
+            snapshot.key().as_ref(),
+            snapshot.node_count.to_be_bytes().as_ref(),
+        ],
+        bump,
         payer = payer,
         space = 8 + size_of::<SnapshotEntry>(),
     )]

--- a/programs/network/src/instructions/initialize.rs
+++ b/programs/network/src/instructions/initialize.rs
@@ -16,7 +16,8 @@ pub struct Initialize<'info> {
 
     #[account(
         init,
-        address = Authority::pubkey(),
+        seeds = [SEED_AUTHORITY],
+        bump,
         payer = admin,
         space = 8 + size_of::<Authority>(),
     )]
@@ -27,7 +28,8 @@ pub struct Initialize<'info> {
 
     #[account(
         init,
-        address = Config::pubkey(),
+        seeds = [SEED_CONFIG],
+        bump,
         payer = admin,
         space = 8 + size_of::<Config>(),
     )]
@@ -35,7 +37,8 @@ pub struct Initialize<'info> {
 
     #[account(
         init,
-        address = Rotator::pubkey(),
+        seeds = [SEED_ROTATOR],
+        bump,
         payer = admin,
         space = 8 + size_of::<Rotator>(),
     )]
@@ -46,7 +49,8 @@ pub struct Initialize<'info> {
 
     #[account(
         init,
-        address = Registry::pubkey(),
+        seeds = [SEED_REGISTRY],
+        bump,
         payer = admin,
         space = 8 + size_of::<Registry>(),
     )]
@@ -54,7 +58,11 @@ pub struct Initialize<'info> {
 
     #[account(
         init,
-        address = Snapshot::pubkey(0),
+        seeds = [
+            SEED_SNAPSHOT,
+            (0 as u64).to_be_bytes().as_ref(),
+        ],
+        bump,
         payer = admin,
         space = 8 + size_of::<Snapshot>(),
     )]

--- a/programs/network/src/instructions/node_register.rs
+++ b/programs/network/src/instructions/node_register.rs
@@ -24,7 +24,12 @@ pub struct NodeRegister<'info> {
 
     #[account(
         init,
-        address = SnapshotEntry::pubkey(snapshot.key(), snapshot.node_count),
+        seeds = [
+            SEED_SNAPSHOT_ENTRY,
+            snapshot.key().as_ref(),
+            snapshot.id.to_be_bytes().as_ref(),
+        ],
+        bump,
         payer = authority,
         space = 8 + size_of::<SnapshotEntry>(),
     )]
@@ -35,7 +40,11 @@ pub struct NodeRegister<'info> {
 
     #[account(
         init,
-        address = Node::pubkey(registry.node_count),
+        seeds = [
+            SEED_NODE,
+            registry.node_count.to_be_bytes().as_ref(),
+        ],
+        bump,
         payer = authority,
         space = 8 + size_of::<Node>(),
     )]

--- a/programs/network/src/instructions/node_stake.rs
+++ b/programs/network/src/instructions/node_stake.rs
@@ -10,7 +10,13 @@ pub struct NodeStake<'info> {
     #[account(address = Config::pubkey())]
     pub config: Account<'info, Config>,
 
-    #[account(address = node.pubkey())]
+    #[account(
+        seeds = [
+            SEED_NODE,
+            node.id.to_be_bytes().as_ref(),
+        ],
+        bump
+    )]
     pub node: Account<'info, Node>,
 
     #[account(

--- a/programs/network/src/instructions/node_unstake.rs
+++ b/programs/network/src/instructions/node_unstake.rs
@@ -14,7 +14,11 @@ pub struct NodeUnstake<'info> {
     pub config: Account<'info, Config>,
 
     #[account(
-        address = node.pubkey(),
+        seeds = [
+            SEED_NODE,
+            node.id.to_be_bytes().as_ref(),
+        ],
+        bump,
         has_one = authority,
     )]
     pub node: Account<'info, Node>,

--- a/programs/network/src/instructions/pool_create.rs
+++ b/programs/network/src/instructions/pool_create.rs
@@ -26,7 +26,7 @@ pub struct PoolCreate<'info> {
     #[account(address = clockwork_pool_program::objects::Config::pubkey())]
     pub pool_program_config: Account<'info, clockwork_pool_program::objects::Config>,
 
-    #[account(mut, address = Rotator::pubkey())]
+    #[account(mut, seeds = [SEED_ROTATOR], bump)]
     pub rotator: Account<'info, Rotator>,
 
     #[account(address = system_program::ID)]
@@ -43,7 +43,7 @@ pub fn handler(ctx: Context<PoolCreate>, name: String, size: usize) -> Result<()
     let system_program = &ctx.accounts.system_program;
 
     // Rotate the worker into its supported pools
-    let rotator_bump = *ctx.bumps.get("rotator").unwrap();
+    let bump = *ctx.bumps.get("rotator").unwrap();
     clockwork_pool_program::cpi::pool_create(
         CpiContext::new_with_signer(
             pool_program.to_account_info(),
@@ -54,7 +54,7 @@ pub fn handler(ctx: Context<PoolCreate>, name: String, size: usize) -> Result<()
                 pool_authority: rotator.to_account_info(),
                 system_program: system_program.to_account_info(),
             },
-            &[&[SEED_ROTATOR, &[rotator_bump]]],
+            &[&[SEED_ROTATOR, &[bump]]],
         ),
         name,
         size,

--- a/programs/network/src/instructions/pools_rotate.rs
+++ b/programs/network/src/instructions/pools_rotate.rs
@@ -34,7 +34,8 @@ pub struct PoolsRotate<'info> {
 
     #[account(
         mut,
-        address = Rotator::pubkey(), 
+        seeds = [SEED_ROTATOR], 
+        bump,
         constraint = Clock::get().unwrap().slot >= rotator.last_rotation_at.checked_add(config.slots_per_rotation).unwrap()
     )]
     pub rotator: Account<'info, Rotator>,
@@ -64,7 +65,7 @@ pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, PoolsRotate<'info>>) -> Re
     require!(rotator.pool_pubkeys.len() == ctx.remaining_accounts.len(), ClockworkError::InvalidPool);
 
     // Rotate the worker into its supported pools
-    let rotator_bump = *ctx.bumps.get("rotator").unwrap();
+    let bump = *ctx.bumps.get("rotator").unwrap();
     for i in 0..ctx.remaining_accounts.len() {
         match ctx.remaining_accounts.get(i) {
             None => return Err(ClockworkError::InvalidPool.into()),
@@ -84,7 +85,7 @@ pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, PoolsRotate<'info>>) -> Re
                                 pool_authority: rotator.to_account_info(),
                                 worker: worker.to_account_info(),
                             },
-                            &[&[SEED_ROTATOR, &[rotator_bump]]],
+                            &[&[SEED_ROTATOR, &[bump]]],
                         ),
                     )?;
                 }

--- a/programs/network/src/instructions/snapshot_create.rs
+++ b/programs/network/src/instructions/snapshot_create.rs
@@ -23,7 +23,11 @@ pub struct SnapshotCreate<'info> {
 
     #[account(
         init,
-        address = Snapshot::pubkey(registry.snapshot_count),
+        seeds = [
+            SEED_SNAPSHOT,
+            registry.snapshot_count.to_be_bytes().as_ref(),
+        ],
+        bump,
         space = 8 + size_of::<Snapshot>(),
         payer = payer
     )]

--- a/programs/network/src/instructions/snapshot_pause.rs
+++ b/programs/network/src/instructions/snapshot_pause.rs
@@ -9,7 +9,7 @@ pub struct SnapshotPause<'info> {
     #[account(mut)]
     pub admin: Signer<'info>,
 
-    #[account(address = Authority::pubkey())]
+    #[account(seeds = [SEED_AUTHORITY], bump)]
     pub authority: Account<'info, Authority>,
 
     #[account(address = clockwork_queue_program::ID)]

--- a/programs/network/src/instructions/snapshot_resume.rs
+++ b/programs/network/src/instructions/snapshot_resume.rs
@@ -9,7 +9,7 @@ pub struct SnapshotResume<'info> {
     #[account(mut)]
     pub admin: Signer<'info>,
 
-    #[account(address = Authority::pubkey())]
+    #[account(seeds = [SEED_AUTHORITY], bump)]
     pub authority: Account<'info, Authority>,
 
     #[account(address = clockwork_queue_program::ID)]

--- a/programs/network/src/objects/config.rs
+++ b/programs/network/src/objects/config.rs
@@ -3,7 +3,7 @@ use {
     std::convert::TryFrom,
 };
 
-const SEED_CONFIG: &[u8] = b"config";
+pub const SEED_CONFIG: &[u8] = b"config";
 
 static DEFAULT_SLOTS_PER_ROTATION: u64 = 10;
 

--- a/programs/network/src/objects/registry.rs
+++ b/programs/network/src/objects/registry.rs
@@ -9,7 +9,7 @@ use {
     std::convert::TryFrom,
 };
 
-const SEED_REGISTRY: &[u8] = b"registry";
+pub const SEED_REGISTRY: &[u8] = b"registry";
 
 /**
  * Registry

--- a/programs/network/src/objects/snapshot.rs
+++ b/programs/network/src/objects/snapshot.rs
@@ -6,7 +6,7 @@ use {
     std::convert::TryFrom,
 };
 
-const SEED_SNAPSHOT: &[u8] = b"snapshot";
+pub const SEED_SNAPSHOT: &[u8] = b"snapshot";
 
 /**
  * Snapshot

--- a/programs/network/src/objects/snapshot_entry.rs
+++ b/programs/network/src/objects/snapshot_entry.rs
@@ -3,7 +3,7 @@ use {
     std::convert::TryFrom,
 };
 
-const SEED_SNAPSHOT_ENTRY: &[u8] = b"snapshot_entry";
+pub const SEED_SNAPSHOT_ENTRY: &[u8] = b"snapshot_entry";
 
 /**
  * SnapshotEntry

--- a/programs/pool/src/instructions/initialize.rs
+++ b/programs/pool/src/instructions/initialize.rs
@@ -12,7 +12,8 @@ pub struct Initialize<'info> {
 
     #[account(
         init,
-        address = Config::pubkey(),
+        seeds = [SEED_CONFIG],
+        bump,
         payer = admin,
         space = 8 + size_of::<Config>(),
     )]

--- a/programs/pool/src/instructions/pool_create.rs
+++ b/programs/pool/src/instructions/pool_create.rs
@@ -18,7 +18,11 @@ pub struct PoolCreate<'info> {
 
     #[account(
         init,
-        address = Pool::pubkey(name),
+        seeds = [
+            SEED_POOL,
+            name.as_bytes(),
+        ],
+        bump,
         payer = payer,
         space = 8 + size_of::<Pool>() + (size_of::<Pubkey>() * size) + name.as_bytes().len(),
     )]

--- a/programs/pool/src/objects/config.rs
+++ b/programs/pool/src/objects/config.rs
@@ -1,6 +1,6 @@
 use anchor_lang::{prelude::*, AnchorDeserialize};
 
-const SEED_CONFIG: &[u8] = b"config";
+pub const SEED_CONFIG: &[u8] = b"config";
 
 /**
  * Config

--- a/programs/pool/src/objects/pool.rs
+++ b/programs/pool/src/objects/pool.rs
@@ -3,7 +3,7 @@ use {
     std::{collections::VecDeque, convert::TryFrom},
 };
 
-const SEED_POOL: &[u8] = b"pool";
+pub const SEED_POOL: &[u8] = b"pool";
 
 /**
  * Pool

--- a/programs/queue/src/instructions/initialize.rs
+++ b/programs/queue/src/instructions/initialize.rs
@@ -15,7 +15,8 @@ pub struct Initialize<'info> {
     /// The program config account.
     #[account(
         init,
-        address = Config::pubkey(),
+        seeds = [SEED_CONFIG],
+        bump,
         payer = admin,
         space = 8 + size_of::<Config>(),
     )]

--- a/programs/queue/src/instructions/queue_crank.rs
+++ b/programs/queue/src/instructions/queue_crank.rs
@@ -26,7 +26,11 @@ pub struct QueueCrank<'info> {
     /// The worker's fee account.
     #[account(
         init_if_needed,
-        address = Fee::pubkey(worker.key()),
+        seeds = [
+            SEED_FEE,
+            worker.key().as_ref(),
+        ],
+        bump,
         payer = worker,
         space = 8 + size_of::<Fee>(),
     )]
@@ -39,7 +43,12 @@ pub struct QueueCrank<'info> {
     /// The queue to crank.
     #[account(
         mut,
-        address = queue.pubkey(),
+        seeds = [
+            SEED_QUEUE,
+            queue.authority.as_ref(),
+            queue.id.as_bytes(),
+        ],
+        bump,
         constraint = !queue.paused @ ClockworkError::PausedQueue
     )]
     pub queue: Box<Account<'info, Queue>>,

--- a/programs/queue/src/instructions/queue_create.rs
+++ b/programs/queue/src/instructions/queue_create.rs
@@ -20,7 +20,12 @@ pub struct QueueCreate<'info> {
     /// The queue to be created.
     #[account(
         init,
-        address = Queue::pubkey(authority.key(), id),
+        seeds = [
+            SEED_QUEUE,
+            authority.key().as_ref(),
+            id.as_bytes(),
+        ],
+        bump,
         payer = payer,
         space = vec![
             8, 

--- a/programs/queue/src/objects/config.rs
+++ b/programs/queue/src/objects/config.rs
@@ -3,7 +3,7 @@ use {
     std::convert::TryFrom,
 };
 
-const SEED_CONFIG: &[u8] = b"config";
+pub const SEED_CONFIG: &[u8] = b"config";
 
 static DEFAULT_CRANK_FEE: u64 = 1_000;
 

--- a/programs/queue/src/objects/fee.rs
+++ b/programs/queue/src/objects/fee.rs
@@ -4,7 +4,7 @@ use {
     std::convert::TryFrom,
 };
 
-const SEED_FEE: &[u8] = b"fee";
+pub const SEED_FEE: &[u8] = b"fee";
 
 /// Escrows the lamport balance owed to a particular worker.
 #[account]

--- a/programs/queue/src/objects/queue.rs
+++ b/programs/queue/src/objects/queue.rs
@@ -15,7 +15,7 @@ use {
     },
 };
 
-const SEED_QUEUE: &[u8] = b"queue";
+pub const SEED_QUEUE: &[u8] = b"queue";
 
 const DEFAULT_RATE_LIMIT: u64 = 10;
 

--- a/programs/webhook/src/instructions/api_new.rs
+++ b/programs/webhook/src/instructions/api_new.rs
@@ -1,5 +1,5 @@
 use {
-    crate::objects::{Api, ApiAccount},
+    crate::objects::{Api, ApiAccount, SEED_API},
     anchor_lang::{prelude::*, system_program},
     std::mem::size_of,
 };
@@ -12,7 +12,12 @@ pub struct ApiNew<'info> {
 
     #[account(
         init,
-        address = Api::pubkey(authority.key(), base_url),
+        seeds = [
+            SEED_API,
+            authority.key().as_ref(),
+            base_url.as_bytes(),
+        ],
+        bump,
         payer = payer,
         space = 8 + size_of::<Api>() + base_url.len(),
     )]

--- a/programs/webhook/src/instructions/initialize.rs
+++ b/programs/webhook/src/instructions/initialize.rs
@@ -1,5 +1,5 @@
 use {
-    crate::objects::{Config, ConfigAccount},
+    crate::objects::{Config, ConfigAccount, SEED_CONFIG},
     anchor_lang::{prelude::*, solana_program::system_program},
     std::mem::size_of,
 };
@@ -11,7 +11,8 @@ pub struct Initialize<'info> {
 
     #[account(
         init,
-        address = Config::pubkey(),
+        seeds = [SEED_CONFIG],
+        bump,
         payer = admin,
         space = 8 + size_of::<Config>(),
     )]

--- a/programs/webhook/src/instructions/request_ack.rs
+++ b/programs/webhook/src/instructions/request_ack.rs
@@ -1,5 +1,5 @@
 use {
-    crate::objects::{Config, Fee, FeeAccount, Request, RequestAccount},
+    crate::objects::{Config, Fee, FeeAccount, Request, RequestAccount, SEED_FEE},
     anchor_lang::{prelude::*, system_program},
     std::mem::size_of,
 };
@@ -18,7 +18,11 @@ pub struct RequestAck<'info> {
 
     #[account(
         init_if_needed,
-        address = Fee::pubkey(worker.key()),
+        seeds = [
+            SEED_FEE,
+            worker.key().as_ref(),
+        ],
+        bump,
         space = 8 + size_of::<Fee>(),
         payer = ack_authority
     )]

--- a/programs/webhook/src/instructions/request_new.rs
+++ b/programs/webhook/src/instructions/request_new.rs
@@ -1,6 +1,6 @@
 use {
     crate::objects::{
-        Api, ApiAccount, Config, HttpMethod, Request, RequestAccount,
+        Api, ApiAccount, Config, HttpMethod, Request, RequestAccount, SEED_REQUEST,
     },
     anchor_lang::{
         prelude::*,
@@ -35,7 +35,13 @@ pub struct RequestNew<'info> {
 
     #[account(
         init,
-        address = Request::pubkey(api.key(), caller.key(), id),
+        seeds = [
+            SEED_REQUEST,
+            api.key().as_ref(),
+            caller.key().as_ref(),
+            id.as_bytes(),
+        ],
+        bump,
         space = 8 + size_of::<Request>(),
         payer = payer
     )]

--- a/programs/webhook/src/objects/api.rs
+++ b/programs/webhook/src/objects/api.rs
@@ -3,7 +3,7 @@ use {
     std::convert::TryFrom,
 };
 
-const SEED_API: &[u8] = b"api";
+pub const SEED_API: &[u8] = b"api";
 
 /**
  * Api
@@ -21,7 +21,7 @@ pub struct Api {
 impl Api {
     pub fn pubkey(authority: Pubkey, base_url: String) -> Pubkey {
         Pubkey::find_program_address(
-            &[SEED_API, authority.as_ref(), base_url.as_bytes().as_ref()],
+            &[SEED_API, authority.as_ref(), base_url.as_bytes()],
             &crate::ID,
         )
         .0

--- a/programs/webhook/src/objects/config.rs
+++ b/programs/webhook/src/objects/config.rs
@@ -3,7 +3,7 @@ use {
     std::convert::TryFrom,
 };
 
-const SEED_CONFIG: &[u8] = b"config";
+pub const SEED_CONFIG: &[u8] = b"config";
 
 /**
  * Defaults

--- a/programs/webhook/src/objects/fee.rs
+++ b/programs/webhook/src/objects/fee.rs
@@ -5,7 +5,7 @@ use {
     std::convert::TryFrom,
 };
 
-const SEED_FEE: &[u8] = b"fee";
+pub const SEED_FEE: &[u8] = b"fee";
 
 /**
  * Fee

--- a/programs/webhook/src/objects/request.rs
+++ b/programs/webhook/src/objects/request.rs
@@ -11,7 +11,7 @@ use {
     },
 };
 
-const SEED_REQUEST: &[u8] = b"request";
+pub const SEED_REQUEST: &[u8] = b"request";
 
 /**
  * Request
@@ -35,12 +35,7 @@ pub struct Request {
 impl Request {
     pub fn pubkey(api: Pubkey, caller: Pubkey, id: String) -> Pubkey {
         Pubkey::find_program_address(
-            &[
-                SEED_REQUEST,
-                api.as_ref(),
-                caller.as_ref(),
-                id.as_bytes().as_ref(),
-            ],
+            &[SEED_REQUEST, api.as_ref(), caller.as_ref(), id.as_bytes()],
             &crate::ID,
         )
         .0

--- a/scripts/mint.sh
+++ b/scripts/mint.sh
@@ -8,8 +8,8 @@ mint=${log: -44}
 log=$(spl-token create-account $mint | grep 'Creating account')
 account=${log: -44}
 
-# Mint 1000 tokens to the current keypair
-balance=1000
+# Mint 10 tokens to the current keypair
+balance=10
 spl-token mint $mint $balance
 
 # Transfer 100 to the validator keypair


### PR DESCRIPTION
Seems like we need to use seeds/bumps to check PDA addresses when using `init` and in order to fetch the `bump` from the transaction context.