### PR TITLE
Avoid submitting pool rotatation txs if the worker is already in the pool

### DIFF
--- a/plugin/src/builders/pool_rotation.rs
+++ b/plugin/src/builders/pool_rotation.rs
@@ -1,4 +1,5 @@
 use {
+    crate::observers::network::PoolPositions,
     clockwork_client::{
         network::objects::{Pool, Registry, Snapshot, SnapshotFrame, Worker},
         Client as ClockworkClient,
@@ -10,6 +11,7 @@ use {
 
 pub fn build_pool_rotation_tx<'a>(
     client: Arc<ClockworkClient>,
+    r_pool_positions: RwLockReadGuard<'a, PoolPositions>,
     r_registry: RwLockReadGuard<'a, Registry>,
     r_snapshot: RwLockReadGuard<'a, Snapshot>,
     r_snapshot_frame: RwLockReadGuard<'a, Option<SnapshotFrame>>,
@@ -22,6 +24,11 @@ pub fn build_pool_rotation_tx<'a>(
 
     // Exit early the snapshot has no stake
     if r_snapshot.total_stake == 0 {
+        return None;
+    }
+
+    // Exit early if the worker is already in the pool.
+    if r_pool_positions.queue_pool.current_position.is_some() {
         return None;
     }
 

--- a/plugin/src/executors/tx.rs
+++ b/plugin/src/executors/tx.rs
@@ -62,11 +62,13 @@ impl TxExecutor {
     }
 
     async fn execute_pool_rotate_txs(self: Arc<Self>, slot: u64) -> PluginResult<()> {
+        let r_pool_positions = self.observers.network.pool_positions.read().await;
         let r_registry = self.observers.network.registry.read().await;
         let r_snapshot = self.observers.network.snapshot.read().await;
         let r_snapshot_frame = self.observers.network.snapshot_frame.read().await;
         match crate::builders::build_pool_rotation_tx(
             self.client.clone(),
+            r_pool_positions,
             r_registry,
             r_snapshot,
             r_snapshot_frame,

--- a/programs/network/src/errors.rs
+++ b/programs/network/src/errors.rs
@@ -2,6 +2,9 @@ use anchor_lang::prelude::*;
 
 #[error_code]
 pub enum ClockworkError {
+    #[msg("The worker is already in the pool")]
+    AlreadyInPool,
+
     #[msg("The commission rate must be an integer between 0 and 100")]
     InvalidCommissionRate,
 

--- a/programs/network/src/instructions/pool_rotate.rs
+++ b/programs/network/src/instructions/pool_rotate.rs
@@ -67,7 +67,7 @@ pub fn handler(ctx: Context<PoolRotate>) -> Result<()> {
     // Verify the worker is not already in the pool.
     require!(
         !pool.workers.contains(&worker.key()),
-        ClockworkError::PoolFull
+        ClockworkError::AlreadyInPool
     );
 
     // Rotate the worker into the pool.


### PR DESCRIPTION
1. Avoid submitting `pool_rotate` transactions if the worker is already in the pool. 
2. Introduce a new `AlreadyInPool` error for the case where the worker is already in the pool. 