### PR TITLE
clean binary before copy

### DIFF
--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -81,7 +81,7 @@ done
 # Copy binaries
 cp -fv "target/$buildVariant/libclockwork_plugin.$libExt" "$installDir"/lib
 for bin in "${BINS}"; do
-  rm -v "$installDir/bin/$bin"
+  rm -fv "$installDir/bin/$bin"
   cp -fv "target/$buildVariant/$bin" "$installDir"/bin
 done
 

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -81,6 +81,7 @@ done
 # Copy binaries
 cp -fv "target/$buildVariant/libclockwork_plugin.$libExt" "$installDir"/lib
 for bin in "${BINS}"; do
+  rm -v "$installDir/bin/$bin"
   cp -fv "target/$buildVariant/$bin" "$installDir"/bin
 done
 


### PR DESCRIPTION
### Problem
`[1]    28309 killed     clockwork`

The cli binary gets killed when running `./bin/clockwork`. The reason is not related to solana dependency version (which is another problem that will be addressed in another PR). 

### How to reproduce

```rustc 1.64.0 (a55dd71d5 2022-09-19)```
```Apple m1```


Playing between different versions and switching back and forth between:
```
git checkout v1.2.15  && ./scripts/build-all.sh . && clockwork
```
and
```
git checkout v1.2.14  && ./scripts/build-all.sh . && clockwork
```

**The issue arises only when trying to execute `./bin/clockwork`**

1 Running `./bin/clockwork` -> process killed
2 Running `./target/release/clockwork` -> ok _(even though it's just the same file copied over)_
3. `diff ./bin/clockwork ./target/release/clock` -> gives an exact match between the two files

### Fix
Tried to modify the build script to force overwrite the `clockwork` binary with different `cp` flags but seems without effect. Only explicitly `rm` the file before the `cp` consistently solves the issue. `cargo clean` seems overkilled.

Haven't been able to identify the exact root cause, might be a bug with incremental builds and codesigning? I noticed `codesign -s - bin/clockwork` does solve the issue, now it might be a side effect of signing, if so that would be specific to mac only.


