### PR TITLE
fix cli errors not showing full text + added KeypairNotFound error

### DIFF
--- a/cli/src/errors.rs
+++ b/cli/src/errors.rs
@@ -22,4 +22,7 @@ pub enum CliError {
     InvalidAddress,
     #[error("Program file does not exist")]
     InvalidProgramFile,
+    #[error("No default signer found in {0}, \
+     run `solana-keygen new`, or `solana config set —keypair <FILEPATH>`")]
+    KeypairNotFound(String),
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,6 +11,9 @@ use cli::app;
 use errors::CliError;
 use processor::process;
 
-fn main() -> Result<(), CliError> {
-    process(&app().get_matches())
+fn main() -> Result<(), CliError>{
+    process(&app().get_matches()).map_err(|e|{
+        println!("{}", e);
+        e
+    })
 }

--- a/cli/src/processor/process.rs
+++ b/cli/src/processor/process.rs
@@ -20,8 +20,9 @@ pub fn process(matches: &ArgMatches) -> Result<(), CliError> {
     let config = CliConfig::load();
 
     // Build the RPC client
-    // TODO If reading the keypair fails, provide a clearer error message for users to set their `solana address`
-    let payer = read_keypair_file(config.keypair_path).unwrap();
+    let payer = read_keypair_file(&config.keypair_path)
+        .map_err(|_| CliError::KeypairNotFound(config.keypair_path))?;
+
     let client = Client::new(payer, config.json_rpc_url);
 
     // Process the command


### PR DESCRIPTION
1. Handle KeyNotFound error
2. Fixed `thiserror` not showing full text

The main function in rust automatically debug print errors returned from its body.
However the `#[error("bla bla")]` attribute of `thiserror` actually works with `fmt::Display` not `fmt::Debug` surprinsigly. See https://github.com/dtolnay/thiserror/issues/178.