### PR TITLE
Resolve bugs in account trigger algorithm

### DIFF
--- a/client/src/thread/instruction/thread_kickoff.rs
+++ b/client/src/thread/instruction/thread_kickoff.rs
@@ -6,12 +6,7 @@ use anchor_lang::{
     InstructionData,
 };
 
-pub fn thread_kickoff(
-    data_hash: Option<u64>,
-    signatory: Pubkey,
-    thread: Pubkey,
-    worker: Pubkey,
-) -> Instruction {
+pub fn thread_kickoff(signatory: Pubkey, thread: Pubkey, worker: Pubkey) -> Instruction {
     Instruction {
         program_id: clockwork_thread_program::ID,
         accounts: vec![
@@ -19,6 +14,6 @@ pub fn thread_kickoff(
             AccountMeta::new(thread, false),
             AccountMeta::new_readonly(worker, false),
         ],
-        data: clockwork_thread_program::instruction::ThreadKickoff { data_hash }.data(),
+        data: clockwork_thread_program::instruction::ThreadKickoff {}.data(),
     }
 }

--- a/plugin/src/builders/thread_exec.rs
+++ b/plugin/src/builders/thread_exec.rs
@@ -1,7 +1,7 @@
 use {
     clockwork_client::{
         network::objects::Worker,
-        thread::objects::{Thread, Trigger, TriggerContext},
+        thread::objects::{Thread, Trigger},
         Client as ClockworkClient,
     },
     dashmap::DashSet,
@@ -15,11 +15,7 @@ use {
         pubkey::Pubkey,
     },
     solana_sdk::{account::Account, commitment_config::CommitmentConfig, transaction::Transaction},
-    std::{
-        collections::hash_map::DefaultHasher,
-        hash::{Hash, Hasher},
-        sync::Arc,
-    },
+    std::sync::Arc,
 };
 
 static TRANSACTION_SIZE_LIMIT: usize = 1_232; // Max byte size of a serialized transaction
@@ -55,9 +51,9 @@ fn build_thread_exec_tx(
 
     // Pre-simulate exec ixs and pack into tx
     let first_instruction = if thread.next_instruction.is_some() {
-        build_exec_ix(client.clone(), thread, signatory_pubkey, worker_id)
+        build_exec_ix(thread, signatory_pubkey, worker_id)
     } else {
-        build_kickoff_ix(client.clone(), thread, signatory_pubkey, worker_id)
+        build_kickoff_ix(thread, signatory_pubkey, worker_id)
     };
     let mut ixs: Vec<Instruction> = vec![first_instruction];
 
@@ -97,7 +93,8 @@ fn build_thread_exec_tx(
                 // If there was an error, then stop packing.
                 if response.value.err.is_some() {
                     info!(
-                        "Error simulating tx: {} logs: {:#?}",
+                        "Error simulating thread: {} tx: {} logs: {:#?}",
+                        thread_pubkey,
                         response.value.err.unwrap(),
                         response.value.logs
                     );
@@ -114,7 +111,6 @@ fn build_thread_exec_tx(
                             if let Ok(sim_thread) = Thread::try_from(account.data) {
                                 if sim_thread.next_instruction.is_some() {
                                     ixs.push(build_exec_ix(
-                                        client.clone(),
                                         sim_thread,
                                         signatory_pubkey,
                                         worker_id,
@@ -143,51 +139,37 @@ fn build_thread_exec_tx(
     Some(tx)
 }
 
-fn build_kickoff_ix(
-    client: Arc<ClockworkClient>,
-    thread: Thread,
-    signatory_pubkey: Pubkey,
-    worker_id: u64,
-) -> Instruction {
+fn build_kickoff_ix(thread: Thread, signatory_pubkey: Pubkey, worker_id: u64) -> Instruction {
     // If this thread is an account listener, grab the account and create the data_hash.
     let mut trigger_account_pubkey: Option<Pubkey> = None;
-    let mut data_hash: Option<u64> = None;
     match thread.trigger {
         Trigger::Account {
             address,
-            offset,
-            size,
+            offset: _,
+            size: _,
         } => {
             // Save the trigger account.
             trigger_account_pubkey = Some(address);
 
             // Begin computing the data hash of this account.
-            let data = client.get_account_data(&address).unwrap();
-            let mut hasher = DefaultHasher::new();
-            if offset + size < data.len() {
-                data[offset..(offset + size)].hash(&mut hasher);
-            }
+            // let data = client.get_account_data(&address).unwrap();
+            // let mut hasher = DefaultHasher::new();
+            // if offset + size < data.len() {
+            //     data[offset..(offset + size)].hash(&mut hasher);
+            // }
+            // let data_hash = hasher.finish();
 
-            // Check the exec context for the prior data hash.
-            match thread.exec_context.clone() {
-                None => {
-                    // This thread has not begun executing yet.
-                    // There is no prior data hash to include in our hash.
-                    data_hash = Some(hasher.finish());
-                }
-                Some(exec_context) => {
-                    match exec_context.trigger_context {
-                        TriggerContext::Account {
-                            data_hash: prior_data_hash,
-                        } => {
-                            // Inject the prior data hash as a seed.
-                            prior_data_hash.hash(&mut hasher);
-                            data_hash = Some(hasher.finish());
-                        }
-                        _ => {}
-                    }
-                }
-            };
+            // // Check the exec context for the prior data hash.
+            // if let Some(exec_context) = thread.exec_context {
+            //     match exec_context.trigger_context {
+            //         TriggerContext::Account {
+            //             data_hash: prior_data_hash,
+            //         } => {
+            //             // Inject the prior data hash as a seed.
+            //         }
+            //         _ => {}
+            //     }
+            // }
         }
         _ => {}
     }
@@ -195,7 +177,6 @@ fn build_kickoff_ix(
     // Build the instruction.
     let thread_pubkey = Thread::pubkey(thread.authority, thread.id);
     let mut kickoff_ix = clockwork_client::thread::instruction::thread_kickoff(
-        data_hash,
         signatory_pubkey,
         thread_pubkey,
         Worker::pubkey(worker_id),
@@ -214,12 +195,7 @@ fn build_kickoff_ix(
     kickoff_ix
 }
 
-fn build_exec_ix(
-    _client: Arc<ClockworkClient>,
-    thread: Thread,
-    signatory_pubkey: Pubkey,
-    worker_id: u64,
-) -> Instruction {
+fn build_exec_ix(thread: Thread, signatory_pubkey: Pubkey, worker_id: u64) -> Instruction {
     // Build the instruction.
     let thread_pubkey = Thread::pubkey(thread.authority, thread.id);
     let mut exec_ix = clockwork_client::thread::instruction::thread_exec(

--- a/plugin/src/observers/thread.rs
+++ b/plugin/src/observers/thread.rs
@@ -86,20 +86,11 @@ impl ThreadObserver {
     ) -> PluginResult<()> {
         self.spawn(|this| async move {
             // Move all threads listening to this account into the executable set.
-            this.listener_threads.retain(|pubkey, thread_pubkeys| {
-                if account_pubkey.eq(pubkey) {
-                    for thread_pubkey in thread_pubkeys.iter() {
-                        this.executable_threads.insert(*thread_pubkey.key());
-                    }
-                    false
-                } else {
-                    true
+            if let Some(entry) = this.listener_threads.get(&account_pubkey) {
+                for thread_pubkey in entry.value().iter() {
+                    this.executable_threads.insert(*thread_pubkey);
                 }
-            });
-
-            // TODO This account update could have just been a lamport change (not a data update).
-            // TODO To optimize, we need to fetch the thread accounts to verify the data update
-
+            }
             Ok(())
         })
     }

--- a/programs/thread/src/errors.rs
+++ b/programs/thread/src/errors.rs
@@ -5,10 +5,6 @@ use anchor_lang::prelude::*;
 /// Errors for the the Clockwork thread program.
 #[error_code]
 pub enum ClockworkError {
-    /// Thrown if a exec instruction requires a `data_hash` argument and one was not provided by the worker.
-    #[msg("This trigger requires a data hash observation")]
-    DataHashNotPresent,
-
     /// Thrown if a exec response has an invalid program ID or cannot be parsed.
     #[msg("The exec response could not be parsed")]
     InvalidExecResponse,
@@ -16,10 +12,6 @@ pub enum ClockworkError {
     /// Thrown if a thread has an invalid state and cannot complete the operation.
     #[msg("The thread is in an invalid state")]
     InvalidThreadState,
-
-    /// Thrown if an account trigger has an invalid range.
-    #[msg("The range is larger than the account size")]
-    RangeOutOfBounds,
 
     /// Thrown if a exec instruction is invalid because the thread's trigger condition has not been met.
     #[msg("The trigger condition has not been activated")]

--- a/programs/thread/src/instructions/thread_kickoff.rs
+++ b/programs/thread/src/instructions/thread_kickoff.rs
@@ -6,7 +6,6 @@ use {
 
 /// Accounts required by the `thread_kickoff` instruction.
 #[derive(Accounts)]
-#[instruction(data_hash: Option<u64>)]
 pub struct ThreadKickoff<'info> {
     /// The signatory.
     #[account(mut)]
@@ -34,12 +33,12 @@ pub struct ThreadKickoff<'info> {
     pub worker: Account<'info, Worker>,
 }
 
-pub fn handler(ctx: Context<ThreadKickoff>, data_hash: Option<u64>) -> Result<()> {
+pub fn handler(ctx: Context<ThreadKickoff>) -> Result<()> {
     // Get accounts.
     let thread = &mut ctx.accounts.thread;
 
     // If this thread does not have a next_instruction, verify the thread's trigger condition is active.
-    thread.kickoff(data_hash, ctx.remaining_accounts)?;
+    thread.kickoff(ctx.remaining_accounts)?;
 
     Ok(())
 }

--- a/programs/thread/src/lib.rs
+++ b/programs/thread/src/lib.rs
@@ -39,8 +39,8 @@ pub mod thread_program {
     }
 
     /// Kicks off a thread if its trigger condition is active.
-    pub fn thread_kickoff(ctx: Context<ThreadKickoff>, data_hash: Option<u64>) -> Result<()> {
-        thread_kickoff::handler(ctx, data_hash)
+    pub fn thread_kickoff(ctx: Context<ThreadKickoff>) -> Result<()> {
+        thread_kickoff::handler(ctx)
     }
 
     /// Pauses an active thread.

--- a/programs/thread/src/objects/thread.rs
+++ b/programs/thread/src/objects/thread.rs
@@ -128,8 +128,7 @@ pub trait ThreadAccount {
         worker: &Account<Worker>,
     ) -> Result<()>;
 
-    fn kickoff(&mut self, data_hash: Option<u64>, remaining_accounts: &[AccountInfo])
-        -> Result<()>;
+    fn kickoff(&mut self, remaining_accounts: &[AccountInfo]) -> Result<()>;
 
     /// Reallocate the memory allocation for the account.
     fn realloc(&mut self) -> Result<()>;
@@ -371,11 +370,7 @@ impl ThreadAccount for Account<'_, Thread> {
         Ok(())
     }
 
-    fn kickoff(
-        &mut self,
-        data_hash: Option<u64>,
-        remaining_accounts: &[AccountInfo],
-    ) -> Result<()> {
+    fn kickoff(&mut self, remaining_accounts: &[AccountInfo]) -> Result<()> {
         let clock = Clock::get().unwrap();
         match self.trigger.clone() {
             Trigger::Account {
@@ -383,12 +378,6 @@ impl ThreadAccount for Account<'_, Thread> {
                 offset,
                 size,
             } => {
-                // Require the provided data hash is non-null.
-                let data_hash = match data_hash {
-                    None => return Err(ClockworkError::DataHashNotPresent.into()),
-                    Some(data_hash) => data_hash,
-                };
-
                 // Verify proof that account data has been updated.
                 match remaining_accounts.first() {
                     None => {}
@@ -406,36 +395,24 @@ impl ThreadAccount for Account<'_, Thread> {
                         if data.len().gt(&range_end) {
                             data[offset..range_end].hash(&mut hasher);
                         } else {
-                            return Err(ClockworkError::RangeOutOfBounds.into());
+                            data[offset..].hash(&mut hasher)
                         }
+                        let data_hash = hasher.finish();
 
-                        // Check the exec context for the prior data hash.
-                        let expected_data_hash = match self.exec_context.clone() {
-                            None => {
-                                // This thread has not begun executing yet.
-                                // There is no prior data hash to include in our hash.
-                                hasher.finish()
-                            }
-                            Some(exec_context) => {
-                                match exec_context.trigger_context {
-                                    TriggerContext::Account {
-                                        data_hash: prior_data_hash,
-                                    } => {
-                                        // Inject the prior data hash as a seed.
-                                        prior_data_hash.hash(&mut hasher);
-                                        hasher.finish()
-                                    }
-                                    _ => return Err(ClockworkError::InvalidThreadState.into()),
+                        // Verify the data hash is different than the prior data hash.
+                        if let Some(exec_context) = self.exec_context {
+                            match exec_context.trigger_context {
+                                TriggerContext::Account {
+                                    data_hash: prior_data_hash,
+                                } => {
+                                    require!(
+                                        data_hash.ne(&prior_data_hash),
+                                        ClockworkError::TriggerNotActive
+                                    )
                                 }
+                                _ => return Err(ClockworkError::InvalidThreadState.into()),
                             }
-                        };
-
-                        // Verify the data hash provided by the worker is equal to the expected data hash.
-                        // This proves the account has been updated since the last exec and the worker has seen the new data.
-                        require!(
-                            data_hash.eq(&expected_data_hash),
-                            ClockworkError::TriggerNotActive
-                        );
+                        }
 
                         // Set a new exec context with the new data hash and slot number.
                         self.exec_context = Some(ExecContext {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -8,6 +8,7 @@ pub mod client {
         thread as thread_program, Client, ClientError, ClientResult, SplToken,
     };
 }
+
 // For programs that need to CPI into Clockwork.
 #[cfg(feature = "thread")]
 pub mod thread_program {


### PR DESCRIPTION
Working with Osec on this one. Our current algorithm includes the prior data hash as a seed when computing the expected data hash. This is actually a problem because it means the workers can always compute some new data hash even if the account data never changed. In other words, our current algorithm for account triggers is broken and does not work as a proof that account data has changed. 

In this PR, I'm no longer including the prior data hash as a seed and also no longer requiring the worker to compute the expected data hash (it's not necessary for the worker to provide this value). I additionally updated how the worker keeps track of executable threads to resolve the issue in CLO-92.

https://linear.app/clockwork-xyz/issue/CLO-92/bug-in-how-workers-are-submitting-transactions-for-account-triggers