### PR TITLE
Relax signatory constraint on workers 

### DIFF
--- a/programs/thread/src/instructions/thread_exec.rs
+++ b/programs/thread/src/instructions/thread_exec.rs
@@ -59,10 +59,7 @@ pub struct ThreadExec<'info> {
     pub thread: Box<Account<'info, Thread>>,
 
     /// The worker.
-    #[account(
-        address = worker.pubkey(),
-        has_one = signatory
-    )]
+    #[account(address = worker.pubkey())]
     pub worker: Account<'info, Worker>,
 }
 

--- a/programs/thread/src/instructions/thread_kickoff.rs
+++ b/programs/thread/src/instructions/thread_kickoff.rs
@@ -26,10 +26,7 @@ pub struct ThreadKickoff<'info> {
     pub thread: Box<Account<'info, Thread>>,
 
     /// The worker.
-    #[account(
-        address = worker.pubkey(),
-        has_one = signatory
-    )]
+    #[account(address = worker.pubkey())]
     pub worker: Account<'info, Worker>,
 }
 


### PR DESCRIPTION
To make the `exec` and `kickoff` ixs truly permissionless and allow explorer users to simulate threads, the signatory constraint on workers must be relaxed. This was never a requirement for Clockwork's security. It was a footgun-protection that prevented workers from accidentally sending their yield to an unintended party. It can safely be remove to allow for more flexible end-user experiences. 