### PR TITLE
Re-arrange packages in cargo publish script

### DIFF
--- a/scripts/cargo-publish.sh
+++ b/scripts/cargo-publish.sh
@@ -14,9 +14,12 @@ sleep 25
 cargo publish -p clockwork-webhook-program
 sleep 25
 
+# Publish SDK
+cargo publish -p clockwork-sdk
+sleep 25
+
 # Publish downstream bins and libs
+# These are most likely to fail due to Anchor dependency issues.
 cargo publish -p clockwork-client
 sleep 25
 cargo publish -p clockwork-cli
-sleep 25 
-cargo publish -p clockwork-sdk


### PR DESCRIPTION
`sdk` no longer depends on `client`. It can moved up in the publishing order of operations. 