### PR TITLE
Add compute unit request to transaction packing algorithm

### DIFF
--- a/plugin/src/builders/thread_exec.rs
+++ b/plugin/src/builders/thread_exec.rs
@@ -1,5 +1,3 @@
-use solana_sdk::compute_budget::ComputeBudgetInstruction;
-
 use {
     clockwork_client::{
         network::state::Worker,
@@ -16,7 +14,10 @@ use {
         instruction::{AccountMeta, Instruction},
         pubkey::Pubkey,
     },
-    solana_sdk::{account::Account, commitment_config::CommitmentConfig, transaction::Transaction},
+    solana_sdk::{
+        account::Account, commitment_config::CommitmentConfig,
+        compute_budget::ComputeBudgetInstruction, transaction::Transaction,
+    },
     std::sync::Arc,
 };
 
@@ -55,14 +56,15 @@ fn build_thread_exec_tx(
     let blockhash = client.get_latest_blockhash().unwrap();
     let signatory_pubkey = client.payer_pubkey();
 
-    // Get the first instruction to pack into the tx.
+    // Grab the first instruction.
     let first_instruction = if thread.next_instruction.is_some() {
         build_exec_ix(thread, signatory_pubkey, worker_id)
     } else {
         build_kickoff_ix(thread, signatory_pubkey, worker_id)
     };
 
-    // Pre-simulate exec ixs and pack as many as possible into tx.
+    // Simulate thread instructions and pack as many as possible into the transaction until we hit mem/cpu limits.
+    // TODO Migrate to versioned transactions.
     let compute_unit_ix = ComputeBudgetInstruction::set_compute_unit_limit(COMPUTE_UNIT_LIMIT);
     let mut units_consumed: Option<u64> = None;
     let mut ixs: Vec<Instruction> = vec![compute_unit_ix.clone(), first_instruction];
@@ -72,13 +74,12 @@ fn build_thread_exec_tx(
         let mut sim_tx = Transaction::new_with_payer(&ixs, Some(&signatory_pubkey));
         sim_tx.sign(&[client.payer()], blockhash);
 
-        // Exit early if tx exceeds Solana's size limit.
-        // TODO With QUIC and Transaction v2 lookup tables, Solana will soon support much larger transaction sizes.
+        // Exit early if the transaction exceeds the size limit.
         if sim_tx.message_data().len() > TRANSACTION_SIZE_LIMIT {
             break;
         }
 
-        // Simulate the complete packed tx.
+        // Run the simulation.
         match client.simulate_transaction_with_config(
             &sim_tx,
             RpcSimulateTransactionConfig {
@@ -91,14 +92,13 @@ fn build_thread_exec_tx(
                 ..RpcSimulateTransactionConfig::default()
             },
         ) {
-            // If there was an error, stop packing and continue with the ixs up until this one.
+            // If there was a simulation error, stop packing and exit now.
             Err(_err) => {
                 break;
             }
 
             // If the simulation was successful, pack the ix into the tx.
             Ok(response) => {
-                // If there was an error, then stop packing.
                 if response.value.err.is_some() {
                     info!(
                         "Error simulating thread: {} tx: {} logs: {:#?}",
@@ -109,10 +109,10 @@ fn build_thread_exec_tx(
                     break;
                 }
 
-                // Save the simulated tx. It is okay to submit.
+                // Update flag tracking if at least one instruction succeed.
                 did_simulation_succeed = true;
 
-                // Save the consumed compute units.
+                // Record the compute units consumed by the simulation.
                 if response.value.units_consumed.is_some() {
                     units_consumed = response.value.units_consumed;
                 }


### PR DESCRIPTION
Users (specifically, Helium) have been hitting the compute unit limit in their transactions. This PR adds a `ComputeBudgetInstruction::set_compute_unit_limit` instruction to the front of every transaction. During simulation, we request the maximum 1.4M compute units available, giving transactions the flexibility of using as many compute units as they need. After simulation, we update the transaction to request only the compute units that were actually consumed. This way, Clockwork transactions will always request exactly the number of compute units they need. This will help with prioritization when https://github.com/solana-labs/solana/issues/28751 lands on Solana. 