### PR TITLE
Use dynamic payer pubkey for future instructions

### DIFF
--- a/programs/network/src/instructions/snapshot_create.rs
+++ b/programs/network/src/instructions/snapshot_create.rs
@@ -60,7 +60,7 @@ pub fn handler(ctx: Context<SnapshotCreate>) -> Result<ThreadResponse> {
             program_id: crate::ID,
             accounts: vec![
                 AccountMetaData::new_readonly(config.key(), false),
-                AccountMetaData::new(payer.key(), true),
+                AccountMetaData::new(clockwork_utils::PAYER_PUBKEY, true),
                 AccountMetaData::new_readonly(registry.key(), false),
                 AccountMetaData::new(snapshot.key(), false),
                 AccountMetaData::new(snapshot_frame_pubkey, false),

--- a/programs/network/src/instructions/snapshot_create.rs
+++ b/programs/network/src/instructions/snapshot_create.rs
@@ -42,7 +42,6 @@ pub struct SnapshotCreate<'info> {
 pub fn handler(ctx: Context<SnapshotCreate>) -> Result<ThreadResponse> {
     // Get accounts
     let config = &ctx.accounts.config;
-    let payer = &ctx.accounts.payer;
     let registry = &ctx.accounts.registry;
     let snapshot = &mut ctx.accounts.snapshot;
     let system_program = &ctx.accounts.system_program;

--- a/programs/network/src/instructions/snapshot_entry_create.rs
+++ b/programs/network/src/instructions/snapshot_entry_create.rs
@@ -76,7 +76,6 @@ pub fn handler(ctx: Context<SnapshotEntryCreate>) -> Result<ThreadResponse> {
     // Get accounts.
     let config = &ctx.accounts.config;
     let delegation = &ctx.accounts.delegation;
-    let payer = &ctx.accounts.payer;
     let registry = &ctx.accounts.registry;
     let snapshot = &mut ctx.accounts.snapshot;
     let snapshot_entry = &mut ctx.accounts.snapshot_entry;

--- a/programs/network/src/instructions/snapshot_entry_create.rs
+++ b/programs/network/src/instructions/snapshot_entry_create.rs
@@ -110,7 +110,7 @@ pub fn handler(ctx: Context<SnapshotEntryCreate>) -> Result<ThreadResponse> {
             accounts: vec![
                 AccountMetaData::new_readonly(config.key(), false),
                 AccountMetaData::new_readonly(next_delegation_pubkey, false),
-                AccountMetaData::new(payer.key(), true),
+                AccountMetaData::new(clockwork_utils::PAYER_PUBKEY, true),
                 AccountMetaData::new_readonly(thread.key(), true),
                 AccountMetaData::new_readonly(registry.key(), false),
                 AccountMetaData::new_readonly(snapshot.key(), false),
@@ -130,7 +130,7 @@ pub fn handler(ctx: Context<SnapshotEntryCreate>) -> Result<ThreadResponse> {
             program_id: crate::ID,
             accounts: vec![
                 AccountMetaData::new_readonly(config.key(), false),
-                AccountMetaData::new(payer.key(), true),
+                AccountMetaData::new(clockwork_utils::PAYER_PUBKEY, true),
                 AccountMetaData::new_readonly(registry.key(), false),
                 AccountMetaData::new(snapshot.key(), false),
                 AccountMetaData::new(next_snapshot_frame_pubkey, false),

--- a/programs/network/src/instructions/snapshot_frame_create.rs
+++ b/programs/network/src/instructions/snapshot_frame_create.rs
@@ -102,7 +102,7 @@ pub fn handler(ctx: Context<SnapshotFrameCreate>) -> Result<ThreadResponse> {
             accounts: vec![
                 AccountMetaData::new_readonly(config.key(), false),
                 AccountMetaData::new_readonly(zeroth_delegation_pubkey, false),
-                AccountMetaData::new(payer.key(), true),
+                AccountMetaData::new(clockwork_utils::PAYER_PUBKEY, true),
                 AccountMetaData::new_readonly(registry.key(), false),
                 AccountMetaData::new_readonly(snapshot.key(), false),
                 AccountMetaData::new(zeroth_snapshot_entry_pubkey, false),
@@ -122,7 +122,7 @@ pub fn handler(ctx: Context<SnapshotFrameCreate>) -> Result<ThreadResponse> {
             program_id: crate::ID,
             accounts: vec![
                 AccountMetaData::new_readonly(config.key(), false),
-                AccountMetaData::new(payer.key(), true),
+                AccountMetaData::new(clockwork_utils::PAYER_PUBKEY, true),
                 AccountMetaData::new_readonly(registry.key(), false),
                 AccountMetaData::new(snapshot.key(), false),
                 AccountMetaData::new(next_snapshot_frame_pubkey, false),

--- a/programs/network/src/instructions/snapshot_frame_create.rs
+++ b/programs/network/src/instructions/snapshot_frame_create.rs
@@ -67,7 +67,6 @@ pub struct SnapshotFrameCreate<'info> {
 pub fn handler(ctx: Context<SnapshotFrameCreate>) -> Result<ThreadResponse> {
     // Get accounts.
     let config = &ctx.accounts.config;
-    let payer = &ctx.accounts.payer;
     let registry = &ctx.accounts.registry;
     let snapshot = &mut ctx.accounts.snapshot;
     let snapshot_frame = &mut ctx.accounts.snapshot_frame;


### PR DESCRIPTION
The network program is currently passing along the payer pubkey to future instructions in the "epoch transition" thread. This creates an implicit assumption that the same worker (payer signatory) will execute all instructions for an invocation of this thread. This PR updates the network program to pass along the dynamic payer pubkey, allowing any worker to finish the thread. 

Follow up, we can likely add a safety guard in the thread program that prevents programs from accidentally passing along the payer pubkey to future instructions. 