### PR TITLE
Safely handle snapshots during epoch transition periods

### DIFF
--- a/plugin/src/builders/pool_rotation.rs
+++ b/plugin/src/builders/pool_rotation.rs
@@ -6,48 +6,45 @@ use {
     },
     solana_sdk::transaction::Transaction,
     std::sync::Arc,
-    tokio::sync::RwLockReadGuard,
 };
 
 pub fn build_pool_rotation_tx<'a>(
     client: Arc<ClockworkClient>,
-    r_pool_positions: RwLockReadGuard<'a, PoolPositions>,
-    r_registry: RwLockReadGuard<'a, Registry>,
-    r_snapshot: RwLockReadGuard<'a, Snapshot>,
-    r_snapshot_frame: RwLockReadGuard<'a, Option<SnapshotFrame>>,
+    pool_positions: PoolPositions,
+    registry: Registry,
+    snapshot: &Snapshot,
+    snapshot_frame: &SnapshotFrame,
     worker_id: u64,
 ) -> Option<Transaction> {
     // Exit early if the rotator is not intialized
-    if r_registry.nonce == 0 {
+    if registry.nonce == 0 {
         return None;
     }
 
     // Exit early the snapshot has no stake
-    if r_snapshot.total_stake == 0 {
+    if snapshot.total_stake == 0 {
         return None;
     }
 
     // Exit early if the worker is already in the pool.
-    if r_pool_positions.thread_pool.current_position.is_some() {
+    if pool_positions.thread_pool.current_position.is_some() {
         return None;
     }
 
     // Exit early if the snapshot frame is none or the worker has no delegated stake.
-    if r_snapshot_frame.is_none() || r_snapshot_frame.clone().unwrap().stake_amount.eq(&0) {
+    if snapshot_frame.stake_amount.eq(&0) {
         return None;
     }
 
     // Check if the rotation window is open for this worker.
-    let is_rotation_window_open = match r_registry.nonce.checked_rem(r_snapshot.total_stake) {
+    let is_rotation_window_open = match registry.nonce.checked_rem(snapshot.total_stake) {
         None => false,
         Some(sample) => {
-            sample >= r_snapshot_frame.clone().unwrap().stake_offset
+            sample >= snapshot_frame.stake_offset
                 && sample
-                    < r_snapshot_frame
-                        .clone()
-                        .unwrap()
+                    < snapshot_frame
                         .stake_offset
-                        .checked_add(r_snapshot_frame.clone().unwrap().stake_amount)
+                        .checked_add(snapshot_frame.stake_amount)
                         .unwrap()
         }
     };
@@ -56,7 +53,7 @@ pub fn build_pool_rotation_tx<'a>(
     }
 
     // Build rotation instruction to rotate the worker into pool 0.
-    let snapshot_pubkey = Snapshot::pubkey(r_snapshot.id);
+    let snapshot_pubkey = Snapshot::pubkey(snapshot.id);
     let ix = clockwork_client::network::instruction::pool_rotate(
         Pool::pubkey(0),
         client.payer_pubkey(),
@@ -64,11 +61,6 @@ pub fn build_pool_rotation_tx<'a>(
         SnapshotFrame::pubkey(snapshot_pubkey, worker_id),
         Worker::pubkey(worker_id),
     );
-
-    // Drop read locks.
-    drop(r_registry);
-    drop(r_snapshot);
-    drop(r_snapshot_frame);
 
     // Build and sign tx.
     let mut tx = Transaction::new_with_payer(&[ix.clone()], Some(&client.payer_pubkey()));

--- a/plugin/src/executors/tx.rs
+++ b/plugin/src/executors/tx.rs
@@ -67,12 +67,6 @@ impl TxExecutor {
         let r_pool_positions = self.observers.network.pool_positions.read().await;
         let r_registry = self.observers.network.registry.read().await;
 
-        info!("Snapshots: {:#?}", self.observers.network.snapshots);
-        info!(
-            "Snapshot frames: {:#?}",
-            self.observers.network.snapshot_frames
-        );
-
         if let Some(snapshot) = self
             .observers
             .network

--- a/plugin/src/executors/tx.rs
+++ b/plugin/src/executors/tx.rs
@@ -1,3 +1,5 @@
+use clockwork_client::network::state::Snapshot;
+
 use {
     crate::{config::PluginConfig, observers::Observers, tpu_client::TpuClient},
     clockwork_client::Client as ClockworkClient,
@@ -64,21 +66,42 @@ impl TxExecutor {
     async fn execute_pool_rotate_txs(self: Arc<Self>, slot: u64) -> PluginResult<()> {
         let r_pool_positions = self.observers.network.pool_positions.read().await;
         let r_registry = self.observers.network.registry.read().await;
-        let r_snapshot = self.observers.network.snapshot.read().await;
-        let r_snapshot_frame = self.observers.network.snapshot_frame.read().await;
-        match crate::builders::build_pool_rotation_tx(
-            self.client.clone(),
-            r_pool_positions,
-            r_registry,
-            r_snapshot,
-            r_snapshot_frame,
-            self.config.worker_id,
-        ) {
-            None => {}
-            Some(tx) => {
-                self.clone().execute_tx(slot, &tx).map_err(|err| err).ok();
+
+        info!("Snapshots: {:#?}", self.observers.network.snapshots);
+        info!(
+            "Snapshot frames: {:#?}",
+            self.observers.network.snapshot_frames
+        );
+
+        if let Some(snapshot) = self
+            .observers
+            .network
+            .snapshots
+            .get(&r_registry.current_epoch)
+        {
+            let snapshot_pubkey = Snapshot::pubkey(snapshot.id);
+            if let Some(snapshot_frame) =
+                self.observers.network.snapshot_frames.get(&snapshot_pubkey)
+            {
+                match crate::builders::build_pool_rotation_tx(
+                    self.client.clone(),
+                    r_pool_positions.clone(),
+                    r_registry.clone(),
+                    snapshot.value(),
+                    snapshot_frame.value(),
+                    self.config.worker_id,
+                ) {
+                    None => {}
+                    Some(tx) => {
+                        self.clone().execute_tx(slot, &tx).map_err(|err| err).ok();
+                    }
+                };
             }
-        };
+        }
+
+        drop(r_pool_positions);
+        drop(r_registry);
+
         Ok(())
     }
 


### PR DESCRIPTION
Currently, workers immediately updates their local snapshots as soon as the new one is created. However, it may take multiple transactions for this snapshot to be taken and for the epoch transition to finish. This means the workers are using an invalid (not yet active) snapshot during the epoch transition period, leading to transactions like the one linked below. This PR updates the plugin to safely handle multiple snapshots and only cutover to the new one once the epoch transition has finished. 

https://explorer.solana.com/tx/3JCYKH41cmZqA5mbXUrWwH1aZoQLtss6cqiWAktsZPhrxF511NS2EUXme894sj3JFskqV5Rsrh6Ppu6wUoomfS5f