### PR TITLE
Remove compute unit buffer

### DIFF
--- a/plugin/src/builders/thread_exec.rs
+++ b/plugin/src/builders/thread_exec.rs
@@ -156,13 +156,9 @@ fn build_thread_exec_tx(
 
     // Set the compute unit limit to be slightly above what was used in the simulation.
     if let Some(units_consumed) = units_consumed {
-        // TODO Is this buffer needed? It is intended to account for variations in PDA derivation cost.
-        let compute_unit_buffer = 1_000;
         _ = std::mem::replace(
             &mut successful_ixs[0],
-            ComputeBudgetInstruction::set_compute_unit_limit(
-                (units_consumed + compute_unit_buffer) as u32,
-            ),
+            ComputeBudgetInstruction::set_compute_unit_limit(units_consumed as u32),
         );
     }
 

--- a/plugin/src/builders/thread_exec.rs
+++ b/plugin/src/builders/thread_exec.rs
@@ -154,7 +154,7 @@ fn build_thread_exec_tx(
         return None;
     }
 
-    // Set the compute unit limit to be slightly above what was used in the simulation.
+    // Set the transaction's compute unit limit to be exactly the amount that was used in simulation.
     if let Some(units_consumed) = units_consumed {
         _ = std::mem::replace(
             &mut successful_ixs[0],


### PR DESCRIPTION
Judging by transaction logs on mainnet, this buffer does not appear to be needed. Every transaction always uses exactly 1000 CUs less than it needs. 