### PR TITLE
Remove pretty-printing from simulation logs

### DIFF
--- a/plugin/src/builders/thread_exec.rs
+++ b/plugin/src/builders/thread_exec.rs
@@ -103,10 +103,10 @@ fn build_thread_exec_tx(
             Ok(response) => {
                 if response.value.err.is_some() {
                     info!(
-                        "Error simulating thread: {} error: {} logs: {:#?}",
+                        "Error simulating thread: {} error: \"{}\" logs: {:?}",
                         thread_pubkey,
                         response.value.err.unwrap(),
-                        response.value.logs
+                        response.value.logs.unwrap_or(vec![])
                     );
                     break;
                 }


### PR DESCRIPTION
Currently, our log parsers have a hard time dealing with the pretty-printed program log statements. This PR updates that particular log statement to be a one-liner so we can parse it more easily into JSON in Logtail. 