### PR TITLE
Introduce TryFromData macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,11 +829,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "clockwork-macros"
+version = "1.4.0"
+dependencies = [
+ "proc-macro2 1.0.46",
+ "quote 1.0.21",
+ "syn 1.0.102",
+]
+
+[[package]]
 name = "clockwork-network-program"
 version = "1.4.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
+ "clockwork-macros",
  "clockwork-utils",
 ]
 
@@ -855,6 +865,7 @@ dependencies = [
  "anchor-lang",
  "chrono",
  "clockwork-cron",
+ "clockwork-macros",
  "clockwork-network-program",
  "clockwork-utils",
  "static-pubkey",
@@ -875,6 +886,7 @@ name = "clockwork-webhook-program"
 version = "1.4.0"
 dependencies = [
  "anchor-lang",
+ "clockwork-macros",
  "clockwork-network-program",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "cli",
     "client",
     "cron",
+    "macros",
     "plugin",
     "programs/*",
     "sdk",

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "clockwork-macros"
+version = "1.4.0"
+description = "Macros for Clockwork"
+edition = "2021"
+license = "AGPL-3.0-or-later"
+homepage = "https://clockwork.xyz"
+repository = "https://github.com/clockwork-xyz/clockwork"
+documentation = "https://docs.clockwork.xyz"
+readme = "./README.md"
+keywords = ["solana"]
+
+[lib]
+name = "clockwork_macros"
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0.60", features = ["full"] }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,21 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::parse_macro_input;
+
+#[proc_macro_derive(TryFromData)]
+pub fn derive_try_from_data_attr(input: TokenStream) -> TokenStream {
+    let account_struct = parse_macro_input!(input as syn::ItemStruct);
+    let account_name = &account_struct.ident;
+    let (impl_gen, ty_gen, where_clause) = account_struct.generics.split_for_impl();
+    proc_macro::TokenStream::from(quote! {
+        #[automatically_derived]
+        impl #impl_gen TryFrom<Vec<u8>> for #account_name #ty_gen #where_clause {
+            type Error = Error;
+            fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
+                #account_name::try_deserialize(&mut data.as_slice())
+            }
+        }
+    })
+}

--- a/programs/network/Cargo.toml
+++ b/programs/network/Cargo.toml
@@ -24,4 +24,5 @@ default = []
 [dependencies]
 anchor-lang = "0.26.0"
 anchor-spl = { features = ["mint", "token"], version = "0.26.0" }
+clockwork-macros = { path = "../../macros", version = "1.4.0" }
 clockwork-utils = { path = "../../utils", version = "1.4.0" }

--- a/programs/network/src/state/config.rs
+++ b/programs/network/src/state/config.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use anchor_lang::{prelude::*, AnchorDeserialize};
 use clockwork_macros::TryFromData;
 

--- a/programs/network/src/state/config.rs
+++ b/programs/network/src/state/config.rs
@@ -1,7 +1,7 @@
-use {
-    anchor_lang::{prelude::*, AnchorDeserialize},
-    std::convert::TryFrom,
-};
+use std::convert::TryFrom;
+
+use anchor_lang::{prelude::*, AnchorDeserialize};
+use clockwork_macros::TryFromData;
 
 pub const SEED_CONFIG: &[u8] = b"config";
 
@@ -10,7 +10,7 @@ pub const SEED_CONFIG: &[u8] = b"config";
  */
 
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct Config {
     pub admin: Pubkey,
     pub epoch_thread: Pubkey,
@@ -21,13 +21,6 @@ pub struct Config {
 impl Config {
     pub fn pubkey() -> Pubkey {
         Pubkey::find_program_address(&[SEED_CONFIG], &crate::ID).0
-    }
-}
-
-impl TryFrom<Vec<u8>> for Config {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        Config::try_deserialize(&mut data.as_slice())
     }
 }
 

--- a/programs/network/src/state/delegation.rs
+++ b/programs/network/src/state/delegation.rs
@@ -1,10 +1,11 @@
 use anchor_lang::{prelude::*, AnchorDeserialize};
+use clockwork_macros::TryFromData;
 
 pub const SEED_DELEGATION: &[u8] = b"delegation";
 
 /// An account to manage a token holder's stake delegation with a particiular a worker.
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct Delegation {
     /// The authority of this delegation account.
     pub authority: Pubkey,
@@ -29,13 +30,6 @@ impl Delegation {
             &crate::ID,
         )
         .0
-    }
-}
-
-impl TryFrom<Vec<u8>> for Delegation {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        Delegation::try_deserialize(&mut data.as_slice())
     }
 }
 

--- a/programs/network/src/state/epoch.rs
+++ b/programs/network/src/state/epoch.rs
@@ -1,4 +1,5 @@
 use anchor_lang::{prelude::*, AnchorDeserialize};
+use clockwork_macros::TryFromData;
 
 use super::Snapshot;
 
@@ -9,7 +10,7 @@ pub const SEED_EPOCH: &[u8] = b"epoch";
  */
 
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct Epoch {
     pub id: u64,
     pub snapshot: Pubkey,
@@ -18,13 +19,6 @@ pub struct Epoch {
 impl Epoch {
     pub fn pubkey(id: u64) -> Pubkey {
         Pubkey::find_program_address(&[SEED_EPOCH, id.to_be_bytes().as_ref()], &crate::ID).0
-    }
-}
-
-impl TryFrom<Vec<u8>> for Epoch {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        Epoch::try_deserialize(&mut data.as_slice())
     }
 }
 

--- a/programs/network/src/state/fee.rs
+++ b/programs/network/src/state/fee.rs
@@ -1,13 +1,11 @@
-use {
-    anchor_lang::{prelude::*, AnchorDeserialize},
-    std::convert::TryFrom,
-};
+use anchor_lang::{prelude::*, AnchorDeserialize};
+use clockwork_macros::TryFromData;
 
 pub const SEED_FEE: &[u8] = b"fee";
 
 /// Escrows the lamport balance owed to a particular worker.
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct Fee {
     /// The number of lamports that are distributable for this epoch period.
     pub distributable_balance: u64,
@@ -19,13 +17,6 @@ impl Fee {
     /// Derive the pubkey of a fee account.
     pub fn pubkey(worker: Pubkey) -> Pubkey {
         Pubkey::find_program_address(&[SEED_FEE, worker.as_ref()], &crate::ID).0
-    }
-}
-
-impl TryFrom<Vec<u8>> for Fee {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        Fee::try_deserialize(&mut data.as_slice())
     }
 }
 

--- a/programs/network/src/state/penalty.rs
+++ b/programs/network/src/state/penalty.rs
@@ -1,13 +1,13 @@
-use {
-    anchor_lang::{prelude::*, AnchorDeserialize},
-    std::convert::TryFrom,
-};
+use std::convert::TryFrom;
+
+use anchor_lang::{prelude::*, AnchorDeserialize};
+use clockwork_macros::TryFromData;
 
 pub const SEED_PENALTY: &[u8] = b"penalty";
 
 /// Escrows the lamport balance owed to a particular worker.
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct Penalty {
     /// The worker who was penalized.
     pub worker: Pubkey,
@@ -17,13 +17,6 @@ impl Penalty {
     /// Derive the pubkey of a fee account.
     pub fn pubkey(worker: Pubkey) -> Pubkey {
         Pubkey::find_program_address(&[SEED_PENALTY, worker.as_ref()], &crate::ID).0
-    }
-}
-
-impl TryFrom<Vec<u8>> for Penalty {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        Penalty::try_deserialize(&mut data.as_slice())
     }
 }
 

--- a/programs/network/src/state/penalty.rs
+++ b/programs/network/src/state/penalty.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use anchor_lang::{prelude::*, AnchorDeserialize};
 use clockwork_macros::TryFromData;
 

--- a/programs/network/src/state/pool.rs
+++ b/programs/network/src/state/pool.rs
@@ -1,7 +1,7 @@
-use {
-    anchor_lang::{prelude::*, AnchorDeserialize},
-    std::{collections::VecDeque, convert::TryFrom},
-};
+use std::collections::VecDeque;
+
+use anchor_lang::{prelude::*, AnchorDeserialize};
+use clockwork_macros::TryFromData;
 
 pub const SEED_POOL: &[u8] = b"pool";
 
@@ -12,7 +12,7 @@ const DEFAULT_POOL_SIZE: usize = 1;
  */
 
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct Pool {
     pub id: u64,
     pub size: usize,
@@ -22,13 +22,6 @@ pub struct Pool {
 impl Pool {
     pub fn pubkey(id: u64) -> Pubkey {
         Pubkey::find_program_address(&[SEED_POOL, id.to_be_bytes().as_ref()], &crate::ID).0
-    }
-}
-
-impl TryFrom<Vec<u8>> for Pool {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        Pool::try_deserialize(&mut data.as_slice())
     }
 }
 

--- a/programs/network/src/state/registry.rs
+++ b/programs/network/src/state/registry.rs
@@ -1,18 +1,17 @@
-use {
-    anchor_lang::{prelude::*, AnchorDeserialize},
-    std::{
-        collections::hash_map::DefaultHasher,
-        convert::TryFrom,
-        hash::{Hash, Hasher},
-    },
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
 };
+
+use anchor_lang::{prelude::*, AnchorDeserialize};
+use clockwork_macros::TryFromData;
 
 pub const SEED_REGISTRY: &[u8] = b"registry";
 
 /// Registry
 
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct Registry {
     pub current_epoch: u64,
     pub locked: bool,
@@ -25,13 +24,6 @@ pub struct Registry {
 impl Registry {
     pub fn pubkey() -> Pubkey {
         Pubkey::find_program_address(&[SEED_REGISTRY], &crate::ID).0
-    }
-}
-
-impl TryFrom<Vec<u8>> for Registry {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        Registry::try_deserialize(&mut data.as_slice())
     }
 }
 

--- a/programs/network/src/state/snapshot.rs
+++ b/programs/network/src/state/snapshot.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use anchor_lang::{prelude::*, AnchorDeserialize};
 use clockwork_macros::TryFromData;
 

--- a/programs/network/src/state/snapshot.rs
+++ b/programs/network/src/state/snapshot.rs
@@ -1,13 +1,13 @@
-use {
-    anchor_lang::{prelude::*, AnchorDeserialize},
-    std::convert::TryFrom,
-};
+use std::convert::TryFrom;
+
+use anchor_lang::{prelude::*, AnchorDeserialize};
+use clockwork_macros::TryFromData;
 
 pub const SEED_SNAPSHOT: &[u8] = b"snapshot";
 
 /// Snapshot
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct Snapshot {
     pub id: u64,
     pub total_frames: u64,
@@ -17,13 +17,6 @@ pub struct Snapshot {
 impl Snapshot {
     pub fn pubkey(id: u64) -> Pubkey {
         Pubkey::find_program_address(&[SEED_SNAPSHOT, id.to_be_bytes().as_ref()], &crate::ID).0
-    }
-}
-
-impl TryFrom<Vec<u8>> for Snapshot {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        Snapshot::try_deserialize(&mut data.as_slice())
     }
 }
 

--- a/programs/network/src/state/snapshot_entry.rs
+++ b/programs/network/src/state/snapshot_entry.rs
@@ -1,4 +1,5 @@
 use anchor_lang::{prelude::*, AnchorDeserialize};
+use clockwork_macros::TryFromData;
 
 pub const SEED_SNAPSHOT_ENTRY: &[u8] = b"snapshot_entry";
 
@@ -7,7 +8,7 @@ pub const SEED_SNAPSHOT_ENTRY: &[u8] = b"snapshot_entry";
  */
 
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct SnapshotEntry {
     pub delegation: Pubkey,
     pub id: u64,
@@ -26,13 +27,6 @@ impl SnapshotEntry {
             &crate::ID,
         )
         .0
-    }
-}
-
-impl TryFrom<Vec<u8>> for SnapshotEntry {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        SnapshotEntry::try_deserialize(&mut data.as_slice())
     }
 }
 

--- a/programs/network/src/state/snapshot_frame.rs
+++ b/programs/network/src/state/snapshot_frame.rs
@@ -1,7 +1,5 @@
-use {
-    anchor_lang::{prelude::*, AnchorDeserialize},
-    std::convert::TryFrom,
-};
+use anchor_lang::{prelude::*, AnchorDeserialize};
+use clockwork_macros::TryFromData;
 
 pub const SEED_SNAPSHOT_FRAME: &[u8] = b"snapshot_frame";
 
@@ -9,7 +7,7 @@ pub const SEED_SNAPSHOT_FRAME: &[u8] = b"snapshot_frame";
  * SnapshotFrame
  */
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct SnapshotFrame {
     pub id: u64,
     pub snapshot: Pubkey,
@@ -30,13 +28,6 @@ impl SnapshotFrame {
             &crate::ID,
         )
         .0
-    }
-}
-
-impl TryFrom<Vec<u8>> for SnapshotFrame {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        SnapshotFrame::try_deserialize(&mut data.as_slice())
     }
 }
 

--- a/programs/network/src/state/unstake.rs
+++ b/programs/network/src/state/unstake.rs
@@ -1,10 +1,11 @@
 use anchor_lang::{prelude::*, AnchorDeserialize};
+use clockwork_macros::TryFromData;
 
 pub const SEED_UNSTAKE: &[u8] = b"unstake";
 
 /// Unstake
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct Unstake {
     pub amount: u64,
     pub authority: Pubkey,
@@ -16,13 +17,6 @@ pub struct Unstake {
 impl Unstake {
     pub fn pubkey(id: u64) -> Pubkey {
         Pubkey::find_program_address(&[SEED_UNSTAKE, id.to_be_bytes().as_ref()], &crate::ID).0
-    }
-}
-
-impl TryFrom<Vec<u8>> for Unstake {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        Unstake::try_deserialize(&mut data.as_slice())
     }
 }
 

--- a/programs/network/src/state/worker.rs
+++ b/programs/network/src/state/worker.rs
@@ -1,14 +1,13 @@
-use {
-    crate::errors::*,
-    anchor_lang::{prelude::*, AnchorDeserialize},
-    std::convert::TryFrom,
-};
+use anchor_lang::{prelude::*, AnchorDeserialize};
+use clockwork_macros::TryFromData;
+
+use crate::errors::*;
 
 pub const SEED_WORKER: &[u8] = b"worker";
 
 /// Worker
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct Worker {
     /// The worker's authority (owner).
     pub authority: Pubkey,
@@ -27,13 +26,6 @@ pub struct Worker {
 impl Worker {
     pub fn pubkey(id: u64) -> Pubkey {
         Pubkey::find_program_address(&[SEED_WORKER, id.to_be_bytes().as_ref()], &crate::ID).0
-    }
-}
-
-impl TryFrom<Vec<u8>> for Worker {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        Worker::try_deserialize(&mut data.as_slice())
     }
 }
 

--- a/programs/thread/Cargo.toml
+++ b/programs/thread/Cargo.toml
@@ -25,6 +25,7 @@ default = []
 anchor-lang = "0.26.0"
 chrono = { version = "0.4.19", default-features = false, features = ["alloc"] }
 clockwork-cron = { path = "../../cron", version = "1.4.0" }
+clockwork-macros = { path = "../../macros", version = "1.4.0" }
 clockwork-network-program = { path = "../network", features = ["cpi"], version = "1.4.0" }
 clockwork-utils = { path = "../../utils", version = "1.4.0" }
 static-pubkey = "1.0.3"

--- a/programs/thread/src/state/thread.rs
+++ b/programs/thread/src/state/thread.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use anchor_lang::{prelude::*, AnchorDeserialize, AnchorSerialize};
 use clockwork_macros::TryFromData;
 

--- a/programs/thread/src/state/thread.rs
+++ b/programs/thread/src/state/thread.rs
@@ -1,9 +1,9 @@
-use {
-    crate::errors::ClockworkError,
-    crate::state::*,
-    anchor_lang::{prelude::*, AnchorDeserialize, AnchorSerialize},
-    std::convert::TryFrom,
-};
+use std::convert::TryFrom;
+
+use anchor_lang::{prelude::*, AnchorDeserialize, AnchorSerialize};
+use clockwork_macros::TryFromData;
+
+use crate::{errors::ClockworkError, state::*};
 
 pub const SEED_THREAD: &[u8] = b"thread";
 
@@ -18,7 +18,7 @@ const MINIMUM_FEE: u64 = 1000;
 
 /// Tracks the current state of a transaction thread on Solana.
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct Thread {
     /// The owner of this thread.
     pub authority: Pubkey,
@@ -52,13 +52,6 @@ impl Thread {
             &crate::ID,
         )
         .0
-    }
-}
-
-impl TryFrom<Vec<u8>> for Thread {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        Thread::try_deserialize(&mut data.as_slice())
     }
 }
 

--- a/programs/thread/src/state/utils.rs
+++ b/programs/thread/src/state/utils.rs
@@ -1,14 +1,13 @@
-use {
-    anchor_lang::{
-        prelude::borsh::BorshSchema,
-        prelude::Pubkey,
-        prelude::*,
-        solana_program::{self, instruction::Instruction},
-        AnchorDeserialize,
-    },
-    static_pubkey::static_pubkey,
-    std::{convert::TryFrom, hash::Hash},
+use std::{convert::TryFrom, hash::Hash};
+
+use anchor_lang::{
+    prelude::borsh::BorshSchema,
+    prelude::Pubkey,
+    prelude::*,
+    solana_program::{self, instruction::Instruction},
+    AnchorDeserialize,
 };
+use static_pubkey::static_pubkey;
 
 /// The stand-in pubkey for delegating a payer address to a worker. All workers are re-imbursed by the user for lamports spent during this delegation.
 pub static PAYER_PUBKEY: Pubkey = static_pubkey!("C1ockworkPayer11111111111111111111111111111");

--- a/programs/webhook/Cargo.toml
+++ b/programs/webhook/Cargo.toml
@@ -23,4 +23,5 @@ default = []
 
 [dependencies]
 anchor-lang = { features = ["init-if-needed"], version = "0.26.0" }
+clockwork-macros = { path = "../../macros", version = "1.4.0" }
 clockwork-network-program = { path = "../network", features = ["cpi"], version = "1.4.0" }

--- a/programs/webhook/src/state/api.rs
+++ b/programs/webhook/src/state/api.rs
@@ -1,7 +1,5 @@
-use {
-    anchor_lang::{prelude::*, AnchorDeserialize},
-    std::convert::TryFrom,
-};
+use anchor_lang::{prelude::*, AnchorDeserialize};
+use clockwork_macros::TryFromData;
 
 pub const SEED_API: &[u8] = b"api";
 
@@ -10,7 +8,7 @@ pub const SEED_API: &[u8] = b"api";
  */
 
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct Api {
     pub ack_authority: Pubkey,
     pub authority: Pubkey,
@@ -25,13 +23,6 @@ impl Api {
             &crate::ID,
         )
         .0
-    }
-}
-
-impl TryFrom<Vec<u8>> for Api {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        Api::try_deserialize(&mut data.as_slice())
     }
 }
 

--- a/programs/webhook/src/state/config.rs
+++ b/programs/webhook/src/state/config.rs
@@ -1,7 +1,5 @@
-use {
-    anchor_lang::{prelude::*, AnchorDeserialize},
-    std::convert::TryFrom,
-};
+use anchor_lang::{prelude::*, AnchorDeserialize};
+use clockwork_macros::TryFromData;
 
 pub const SEED_CONFIG: &[u8] = b"config";
 
@@ -17,7 +15,7 @@ static DEFAULT_TIMEOUT_THRESHOLD: u64 = 100; // 100 slots
  */
 
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct Config {
     pub admin: Pubkey,
     pub request_fee: u64, // Amount to charge per request and payout to workers
@@ -27,13 +25,6 @@ pub struct Config {
 impl Config {
     pub fn pubkey() -> Pubkey {
         Pubkey::find_program_address(&[SEED_CONFIG], &crate::ID).0
-    }
-}
-
-impl TryFrom<Vec<u8>> for Config {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        Config::try_deserialize(&mut data.as_slice())
     }
 }
 

--- a/programs/webhook/src/state/fee.rs
+++ b/programs/webhook/src/state/fee.rs
@@ -1,9 +1,7 @@
-use super::Request;
+use anchor_lang::{prelude::*, AnchorDeserialize};
+use clockwork_macros::TryFromData;
 
-use {
-    anchor_lang::{prelude::*, AnchorDeserialize},
-    std::convert::TryFrom,
-};
+use super::Request;
 
 pub const SEED_FEE: &[u8] = b"fee";
 
@@ -12,7 +10,7 @@ pub const SEED_FEE: &[u8] = b"fee";
  */
 
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct Fee {
     pub authority: Pubkey,
     pub admin_balance: u64,
@@ -22,13 +20,6 @@ pub struct Fee {
 impl Fee {
     pub fn pubkey(authority: Pubkey) -> Pubkey {
         Pubkey::find_program_address(&[SEED_FEE, authority.as_ref()], &crate::ID).0
-    }
-}
-
-impl TryFrom<Vec<u8>> for Fee {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        Fee::try_deserialize(&mut data.as_slice())
     }
 }
 

--- a/programs/webhook/src/state/request.rs
+++ b/programs/webhook/src/state/request.rs
@@ -1,15 +1,14 @@
-use super::Api;
-
-use {
-    crate::errors::ClockworkError,
-    anchor_lang::{prelude::*, AnchorDeserialize},
-    std::{
-        collections::HashMap,
-        convert::TryFrom,
-        fmt::{Display, Formatter},
-        str::FromStr,
-    },
+use std::{
+    collections::HashMap,
+    fmt::{Display, Formatter},
+    str::FromStr,
 };
+
+use super::Api;
+use crate::errors::ClockworkError;
+
+use anchor_lang::{prelude::*, AnchorDeserialize};
+use clockwork_macros::TryFromData;
 
 pub const SEED_REQUEST: &[u8] = b"request";
 
@@ -18,7 +17,7 @@ pub const SEED_REQUEST: &[u8] = b"request";
  */
 
 #[account]
-#[derive(Debug)]
+#[derive(Debug, TryFromData)]
 pub struct Request {
     pub api: Pubkey,
     pub caller: Pubkey,
@@ -39,13 +38,6 @@ impl Request {
             &crate::ID,
         )
         .0
-    }
-}
-
-impl TryFrom<Vec<u8>> for Request {
-    type Error = Error;
-    fn try_from(data: Vec<u8>) -> std::result::Result<Self, Self::Error> {
-        Request::try_deserialize(&mut data.as_slice())
     }
 }
 


### PR DESCRIPTION
This PR introduces a new macro called `TryFromData` which automatically derives the `TryFrom<Vec<u8>>` trait that we implement on every account. 