### PR TITLE
Add clone and url flags to localnet CLI command

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -57,9 +57,9 @@ pub enum CliCommand {
 
     // Localnet commands
     Localnet {
-        program_infos: Vec<ProgramInfo>,
         clone_addresses: Vec<Pubkey>,
-        url: Option<String>,
+        network_url: Option<String>,
+        program_infos: Vec<ProgramInfo>,
     },
 
     // Pool commands

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -58,6 +58,8 @@ pub enum CliCommand {
     // Localnet commands
     Localnet {
         program_infos: Vec<ProgramInfo>,
+        clone_addresses: Vec<Pubkey>,
+        url: Option<String>,
     },
 
     // Pool commands
@@ -319,7 +321,27 @@ pub fn app() -> Command<'static> {
                        If the ledger already exists then this parameter is silently ignored. \
                        First argument can be a pubkey string or path to a keypair",
                         ),
-                ),
+                )
+                .arg(
+                    Arg::with_name("clone")
+                    .long("clone")
+                    .short('c')
+                    .value_names(&["ADDRESS"])
+                    .takes_value(true)
+                    .number_of_values(1)
+                    .multiple(true)
+                    .help("Copy an account from the cluster referenced by the --url argument the genesis configuration. If the ledger already exists then this parameter is silently ignored")
+                )
+                .arg(
+                    Arg::with_name("url")
+                    .long("url")
+                    .short('u')
+                    .value_names(&["URL_OR_MONIKER"])
+                    .takes_value(true)
+                    .number_of_values(1)
+                    .multiple(false)
+                    .help("URL for Solana's JSON RPC or moniker (or their first letter): [mainnet-beta, testnet, devnet, localhost]")
+                )
         )
         .subcommand(
             Command::new("pool")

--- a/cli/src/parser.rs
+++ b/cli/src/parser.rs
@@ -82,9 +82,9 @@ fn parse_bpf_command(matches: &ArgMatches) -> Result<CliCommand, CliError> {
     }
 
     Ok(CliCommand::Localnet {
-        program_infos,
         clone_addresses,
-        url: parse_string("url", matches).ok(),
+        network_url: parse_string("url", matches).ok(),
+        program_infos,
     })
 }
 

--- a/cli/src/parser.rs
+++ b/cli/src/parser.rs
@@ -39,6 +39,7 @@ impl TryFrom<&ArgMatches> for CliCommand {
 // Command parsers
 fn parse_bpf_command(matches: &ArgMatches) -> Result<CliCommand, CliError> {
     let mut program_infos = Vec::<ProgramInfo>::new();
+    let mut clone_addresses = Vec::<Pubkey>::new();
 
     if let Some(values) = matches.values_of("bpf_program") {
         let values: Vec<&str> = values.collect::<Vec<_>>();
@@ -69,7 +70,22 @@ fn parse_bpf_command(matches: &ArgMatches) -> Result<CliCommand, CliError> {
         }
     }
 
-    Ok(CliCommand::Localnet { program_infos })
+    if let Some(values) = matches.values_of("clone") {
+        let values: Vec<&str> = values.collect::<Vec<_>>();
+        for value in values {
+            let address = value
+                .parse::<Pubkey>()
+                .map_err(|_| CliError::InvalidAddress)
+                .unwrap();
+            clone_addresses.push(address);
+        }
+    }
+
+    Ok(CliCommand::Localnet {
+        program_infos,
+        clone_addresses,
+        url: parse_string("url", matches).ok(),
+    })
 }
 
 fn parse_api_command(matches: &ArgMatches) -> Result<CliCommand, CliError> {

--- a/cli/src/processor/localnet.rs
+++ b/cli/src/processor/localnet.rs
@@ -27,9 +27,9 @@ use {
 
 pub fn start(
     client: &Client,
-    program_infos: Vec<ProgramInfo>,
-    network_url: Option<String>,
     clone_addresses: Vec<Pubkey>,
+    network_url: Option<String>,
+    program_infos: Vec<ProgramInfo>,
 ) -> Result<(), CliError> {
     check_test_validator_version();
     // Start the validator

--- a/cli/src/processor/localnet.rs
+++ b/cli/src/processor/localnet.rs
@@ -25,11 +25,17 @@ use {
     std::process::{Child, Command},
 };
 
-pub fn start(client: &Client, program_infos: Vec<ProgramInfo>) -> Result<(), CliError> {
+pub fn start(
+    client: &Client,
+    program_infos: Vec<ProgramInfo>,
+    network_url: Option<String>,
+    clone_addresses: Vec<Pubkey>,
+) -> Result<(), CliError> {
     check_test_validator_version();
     // Start the validator
-    let validator_process = &mut start_test_validator(client, program_infos)
-        .map_err(|err| CliError::FailedLocalnet(err.to_string()))?;
+    let validator_process =
+        &mut start_test_validator(client, program_infos, network_url, clone_addresses)
+            .map_err(|err| CliError::FailedLocalnet(err.to_string()))?;
 
     // Initialize Clockwork
     let mint_pubkey =
@@ -212,7 +218,12 @@ fn create_threads(client: &Client, mint_pubkey: Pubkey) -> Result<()> {
     Ok(())
 }
 
-fn start_test_validator(client: &Client, program_infos: Vec<ProgramInfo>) -> Result<Child> {
+fn start_test_validator(
+    client: &Client,
+    program_infos: Vec<ProgramInfo>,
+    network_url: Option<String>,
+    clone_addresses: Vec<Pubkey>,
+) -> Result<Child> {
     println!("Starting test validator");
 
     // Get Clockwork home path
@@ -225,6 +236,8 @@ fn start_test_validator(client: &Client, program_infos: Vec<ProgramInfo>) -> Res
         .bpf_program(home_dir, clockwork_client::network::ID, "network")
         .bpf_program(home_dir, clockwork_client::thread::ID, "thread")
         .bpf_program(home_dir, clockwork_client::webhook::ID, "webhook")
+        .network_url(network_url)
+        .clone_addresses(clone_addresses)
         .add_programs_with_path(program_infos)
         .geyser_plugin_config(home_dir)
         .spawn()
@@ -283,6 +296,8 @@ trait TestValidatorHelpers {
         program_name: &str,
     ) -> &mut Command;
     fn geyser_plugin_config(&mut self, home_dir: &str) -> &mut Command;
+    fn network_url(&mut self, url: Option<String>) -> &mut Command;
+    fn clone_addresses(&mut self, clone_addresses: Vec<Pubkey>) -> &mut Command;
 }
 
 impl TestValidatorHelpers for Command {
@@ -310,5 +325,19 @@ impl TestValidatorHelpers for Command {
     fn geyser_plugin_config(&mut self, home_dir: &str) -> &mut Command {
         self.arg("--geyser-plugin-config")
             .arg(lib_path(home_dir, "geyser-plugin-config.json"))
+    }
+
+    fn network_url(&mut self, url: Option<String>) -> &mut Command {
+        if let Some(url) = url {
+            self.arg("--url").arg(url);
+        }
+        self
+    }
+
+    fn clone_addresses(&mut self, clone_addresses: Vec<Pubkey>) -> &mut Command {
+        for clone_address in clone_addresses {
+            self.arg("--clone").arg(clone_address.to_string());
+        }
+        self
     }
 }

--- a/cli/src/processor/process.rs
+++ b/cli/src/processor/process.rs
@@ -14,9 +14,9 @@ pub fn process(matches: &ArgMatches) -> Result<(), CliError> {
     match command {
         // Set solana config if using localnet command
         CliCommand::Localnet {
-            program_infos: _,
-            url: _,
             clone_addresses: _,
+            network_url: _,
+            program_infos: _,
         } => {
             // TODO Verify the Solana CLI version is compatable with this build.
             set_solana_config().map_err(|err| CliError::FailedLocalnet(err.to_string()))?
@@ -66,10 +66,10 @@ pub fn process(matches: &ArgMatches) -> Result<(), CliError> {
         }
         CliCommand::Initialize { mint } => super::initialize::initialize(&client, mint),
         CliCommand::Localnet {
-            program_infos,
             clone_addresses,
-            url,
-        } => super::localnet::start(&client, program_infos, url, clone_addresses),
+            network_url,
+            program_infos,
+        } => super::localnet::start(&client, clone_addresses, network_url, program_infos),
         CliCommand::PoolGet { id } => super::pool::get(&client, id),
         CliCommand::PoolList {} => super::pool::list(&client),
         CliCommand::PoolUpdate { id, size } => super::pool::update(&client, id, size),

--- a/cli/src/processor/process.rs
+++ b/cli/src/processor/process.rs
@@ -13,7 +13,11 @@ pub fn process(matches: &ArgMatches) -> Result<(), CliError> {
 
     match command {
         // Set solana config if using localnet command
-        CliCommand::Localnet { program_infos: _ } => {
+        CliCommand::Localnet {
+            program_infos: _,
+            url: _,
+            clone_addresses: _,
+        } => {
             // TODO Verify the Solana CLI version is compatable with this build.
             set_solana_config().map_err(|err| CliError::FailedLocalnet(err.to_string()))?
         }
@@ -61,7 +65,11 @@ pub fn process(matches: &ArgMatches) -> Result<(), CliError> {
             super::explorer::thread_url(pubkey, config)
         }
         CliCommand::Initialize { mint } => super::initialize::initialize(&client, mint),
-        CliCommand::Localnet { program_infos } => super::localnet::start(&client, program_infos),
+        CliCommand::Localnet {
+            program_infos,
+            clone_addresses,
+            url,
+        } => super::localnet::start(&client, program_infos, url, clone_addresses),
         CliCommand::PoolGet { id } => super::pool::get(&client, id),
         CliCommand::PoolList {} => super::pool::list(&client),
         CliCommand::PoolUpdate { id, size } => super::pool::update(&client, id, size),


### PR DESCRIPTION
Allows users to use the `--clone` and `--url` flags to copy account state from mainnnet/testnet/devnet into their local environments.