### PR TITLE
Change thread id to a Vec<u8>

### DIFF
--- a/cli/src/processor/thread.rs
+++ b/cli/src/processor/thread.rs
@@ -21,10 +21,10 @@ pub fn create(
     instructions: Vec<InstructionData>,
     trigger: Trigger,
 ) -> Result<(), CliError> {
-    let thread_pubkey = Thread::pubkey(client.payer_pubkey(), id.clone());
+    let thread_pubkey = Thread::pubkey(client.payer_pubkey(), id.clone().into_bytes());
     let ix = clockwork_client::thread::instruction::thread_create(
         client.payer_pubkey(),
-        id.clone(),
+        id.into_bytes(),
         instructions,
         client.payer_pubkey(),
         thread_pubkey,
@@ -36,7 +36,7 @@ pub fn create(
 }
 
 pub fn delete(client: &Client, id: String) -> Result<(), CliError> {
-    let thread_pubkey = Thread::pubkey(client.payer_pubkey(), id);
+    let thread_pubkey = Thread::pubkey(client.payer_pubkey(), id.into_bytes());
     let ix = clockwork_client::thread::instruction::thread_delete(
         client.payer_pubkey(),
         client.payer_pubkey(),
@@ -55,7 +55,7 @@ pub fn get(client: &Client, address: Pubkey) -> Result<(), CliError> {
 }
 
 pub fn pause(client: &Client, id: String) -> Result<(), CliError> {
-    let thread_pubkey = Thread::pubkey(client.payer_pubkey(), id.clone());
+    let thread_pubkey = Thread::pubkey(client.payer_pubkey(), id.into_bytes());
     let ix =
         clockwork_client::thread::instruction::thread_pause(client.payer_pubkey(), thread_pubkey);
     client.send_and_confirm(&[ix], &[client.payer()]).unwrap();
@@ -64,7 +64,7 @@ pub fn pause(client: &Client, id: String) -> Result<(), CliError> {
 }
 
 pub fn resume(client: &Client, id: String) -> Result<(), CliError> {
-    let thread_pubkey = Thread::pubkey(client.payer_pubkey(), id.clone());
+    let thread_pubkey = Thread::pubkey(client.payer_pubkey(), id.into_bytes());
     let ix =
         clockwork_client::thread::instruction::thread_resume(client.payer_pubkey(), thread_pubkey);
     client.send_and_confirm(&[ix], &[client.payer()]).unwrap();
@@ -73,7 +73,7 @@ pub fn resume(client: &Client, id: String) -> Result<(), CliError> {
 }
 
 pub fn stop(client: &Client, id: String) -> Result<(), CliError> {
-    let thread_pubkey = Thread::pubkey(client.payer_pubkey(), id.clone());
+    let thread_pubkey = Thread::pubkey(client.payer_pubkey(), id.into_bytes());
     let ix =
         clockwork_client::thread::instruction::thread_stop(client.payer_pubkey(), thread_pubkey);
     client.send_and_confirm(&[ix], &[client.payer()]).unwrap();
@@ -87,7 +87,7 @@ pub fn update(
     rate_limit: Option<u64>,
     schedule: Option<String>,
 ) -> Result<(), CliError> {
-    let thread_pubkey = Thread::pubkey(client.payer_pubkey(), id.clone());
+    let thread_pubkey = Thread::pubkey(client.payer_pubkey(), id.into_bytes());
     let trigger = if let Some(schedule) = schedule {
         Some(Trigger::Cron {
             schedule,
@@ -99,6 +99,7 @@ pub fn update(
     let settings = ThreadSettings {
         fee: None,
         instructions: None,
+        name: None,
         rate_limit,
         trigger,
     };
@@ -118,6 +119,5 @@ pub fn parse_pubkey_from_id_or_address(
     address: Option<Pubkey>,
 ) -> Result<Pubkey, CliError> {
     let address_from_id = id.map(|str| Thread::pubkey(authority, str.into()));
-
     address.or(address_from_id).ok_or(CliError::InvalidAddress)
 }

--- a/client/src/thread/instruction/thread_create.rs
+++ b/client/src/thread/instruction/thread_create.rs
@@ -12,7 +12,7 @@ use {
 
 pub fn thread_create(
     authority: Pubkey,
-    id: String,
+    id: Vec<u8>,
     instructions: Vec<ClockworkInstructionData>,
     payer: Pubkey,
     thread: Pubkey,

--- a/programs/thread/src/instructions/thread_create.rs
+++ b/programs/thread/src/instructions/thread_create.rs
@@ -12,7 +12,7 @@ const MINIMUM_FEE: u64 = 1000;
 
 /// Accounts required by the `thread_create` instruction.
 #[derive(Accounts)]
-#[instruction(id: String, instructions: Vec<InstructionData>, trigger: Trigger)]
+#[instruction(id: Vec<u8>, instructions: Vec<InstructionData>,  trigger: Trigger)]
 pub struct ThreadCreate<'info> {
     /// The authority (owner) of the thread.
     #[account()]
@@ -32,14 +32,14 @@ pub struct ThreadCreate<'info> {
         seeds = [
             SEED_THREAD,
             authority.key().as_ref(),
-            id.as_bytes(),
+            id.as_slice(),
         ],
         bump,
         payer = payer,
         space = vec![
             8, 
             size_of::<Thread>(), 
-            id.as_bytes().len(),
+            id.len(),
             instructions.try_to_vec()?.len(),  
             trigger.try_to_vec()?.len()
         ].iter().sum()
@@ -47,7 +47,7 @@ pub struct ThreadCreate<'info> {
     pub thread: Account<'info, Thread>,
 }
 
-pub fn handler(ctx: Context<ThreadCreate>, id: String, instructions: Vec<InstructionData>, trigger: Trigger) -> Result<()> {
+pub fn handler(ctx: Context<ThreadCreate>, id: Vec<u8>, instructions: Vec<InstructionData>, trigger: Trigger) -> Result<()> {
     // Get accounts
     let authority = &ctx.accounts.authority;
     let thread = &mut ctx.accounts.thread;
@@ -61,6 +61,7 @@ pub fn handler(ctx: Context<ThreadCreate>, id: String, instructions: Vec<Instruc
     thread.fee = MINIMUM_FEE;
     thread.id = id;
     thread.instructions = instructions;
+    thread.name = String::new();
     thread.next_instruction = None;
     thread.paused = false;
     thread.rate_limit = DEFAULT_RATE_LIMIT;

--- a/programs/thread/src/instructions/thread_delete.rs
+++ b/programs/thread/src/instructions/thread_delete.rs
@@ -17,7 +17,7 @@ pub struct ThreadDelete<'info> {
         seeds = [
             SEED_THREAD,
             thread.authority.as_ref(),
-            thread.id.as_bytes(),
+            thread.id.as_slice(),
         ],
         bump = thread.bump,
         has_one = authority,

--- a/programs/thread/src/instructions/thread_exec.rs
+++ b/programs/thread/src/instructions/thread_exec.rs
@@ -61,7 +61,7 @@ pub struct ThreadExec<'info> {
         seeds = [
             SEED_THREAD,
             thread.authority.as_ref(),
-            thread.id.as_bytes(),
+            thread.id.as_slice(),
         ],
         bump = thread.bump,
         constraint = !thread.paused @ ClockworkError::ThreadPaused,
@@ -125,7 +125,7 @@ pub fn handler(ctx: Context<ThreadExec>) -> Result<()> {
         &[&[
             SEED_THREAD,
             thread.authority.as_ref(),
-            thread.id.as_bytes(),
+            thread.id.as_slice(),
             &[thread.bump],
         ]],
     )?;

--- a/programs/thread/src/instructions/thread_kickoff.rs
+++ b/programs/thread/src/instructions/thread_kickoff.rs
@@ -24,7 +24,7 @@ pub struct ThreadKickoff<'info> {
         seeds = [
             SEED_THREAD,
             thread.authority.as_ref(),
-            thread.id.as_bytes(),
+            thread.id.as_slice(),
         ],
         bump = thread.bump,
         constraint = !thread.paused @ ClockworkError::ThreadPaused,

--- a/programs/thread/src/instructions/thread_pause.rs
+++ b/programs/thread/src/instructions/thread_pause.rs
@@ -13,7 +13,7 @@ pub struct ThreadPause<'info> {
         seeds = [
             SEED_THREAD,
             thread.authority.as_ref(),
-            thread.id.as_bytes(),
+            thread.id.as_slice(),
         ],
         bump = thread.bump,
         has_one = authority

--- a/programs/thread/src/instructions/thread_resume.rs
+++ b/programs/thread/src/instructions/thread_resume.rs
@@ -13,7 +13,7 @@ pub struct ThreadResume<'info> {
         seeds = [
             SEED_THREAD,
             thread.authority.as_ref(),
-            thread.id.as_bytes(),
+            thread.id.as_slice(),
         ],
         bump = thread.bump,
         has_one = authority

--- a/programs/thread/src/instructions/thread_stop.rs
+++ b/programs/thread/src/instructions/thread_stop.rs
@@ -13,7 +13,7 @@ pub struct ThreadStop<'info> {
         seeds = [
             SEED_THREAD,
             thread.authority.as_ref(),
-            thread.id.as_bytes(),
+            thread.id.as_slice(),
         ],
         bump = thread.bump,
         has_one = authority

--- a/programs/thread/src/instructions/thread_update.rs
+++ b/programs/thread/src/instructions/thread_update.rs
@@ -30,7 +30,7 @@ pub struct ThreadUpdate<'info> {
             seeds = [
                 SEED_THREAD,
                 thread.authority.as_ref(),
-                thread.id.as_bytes(),
+                thread.id.as_slice(),
             ],
             bump = thread.bump,
             has_one = authority,

--- a/programs/thread/src/instructions/thread_withdraw.rs
+++ b/programs/thread/src/instructions/thread_withdraw.rs
@@ -21,7 +21,7 @@ pub struct ThreadWithdraw<'info> {
         seeds = [
             SEED_THREAD,
             thread.authority.as_ref(),
-            thread.id.as_bytes(),
+            thread.id.as_slice(),
         ],
         bump = thread.bump,
         has_one = authority,

--- a/programs/thread/src/lib.rs
+++ b/programs/thread/src/lib.rs
@@ -34,7 +34,7 @@ pub mod thread_program {
     /// Creates a new transaction thread.
     pub fn thread_create(
         ctx: Context<ThreadCreate>,
-        id: String,
+        id: Vec<u8>,
         instructions: Vec<InstructionData>,
         trigger: Trigger,
     ) -> Result<()> {

--- a/programs/thread/src/state/thread.rs
+++ b/programs/thread/src/state/thread.rs
@@ -20,9 +20,11 @@ pub struct Thread {
     /// The number of lamports to payout to workers per execution.
     pub fee: u64,
     /// The id of the thread, given by the authority.
-    pub id: String,
+    pub id: Vec<u8>,
     /// The instructions to be executed.
     pub instructions: Vec<InstructionData>,
+    /// The name of the thread.
+    pub name: String,
     /// The next instruction to be executed.
     pub next_instruction: Option<InstructionData>,
     /// Whether or not the thread is currently paused.
@@ -35,9 +37,9 @@ pub struct Thread {
 
 impl Thread {
     /// Derive the pubkey of a thread account.
-    pub fn pubkey(authority: Pubkey, id: String) -> Pubkey {
+    pub fn pubkey(authority: Pubkey, id: Vec<u8>) -> Pubkey {
         Pubkey::find_program_address(
-            &[SEED_THREAD, authority.as_ref(), id.as_bytes()],
+            &[SEED_THREAD, authority.as_ref(), id.as_slice()],
             &crate::ID,
         )
         .0
@@ -144,6 +146,7 @@ pub enum TriggerContext {
 pub struct ThreadSettings {
     pub fee: Option<u64>,
     pub instructions: Option<Vec<InstructionData>>,
+    pub name: Option<String>,
     pub rate_limit: Option<u64>,
     pub trigger: Option<Trigger>,
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -24,7 +24,7 @@ pub mod cpi {
 
     pub fn thread_create<'info>(
         ctx: CpiContext<'_, '_, '_, 'info, ThreadCreate<'info>>,
-        id: String,
+        id: Vec<u8>,
         instructions: Vec<crate::state::InstructionData>,
         trigger: crate::state::Trigger,
     ) -> Result<()> {


### PR DESCRIPTION
Currently, we generate thread PDAs using the authority (pubkey) and id (string). Using strings for PDA seeds is problematic because one cannot efficiently encode a pubkey as a string for use as a seed. By changing id to a Vec<u8>, we can support a more flexible array of id scheming conventions. 

This PR also introduces a new field named "name" which can retain human-readability value of strings and also is mutable. 