### PR TITLE
Add atomic lock to transaction executor

### DIFF
--- a/plugin/src/executors/tx.rs
+++ b/plugin/src/executors/tx.rs
@@ -1,4 +1,7 @@
-use std::{fmt::Debug, sync::Arc};
+use std::{
+    fmt::Debug,
+    sync::{atomic::AtomicBool, Arc},
+};
 
 use clockwork_client::{
     network::state::{Pool, Registry, Snapshot, SnapshotFrame, Worker},
@@ -38,6 +41,7 @@ pub struct TxExecutor {
     pub runtime: Arc<Runtime>,
     pub tpu_client: Arc<TpuClient>,
     pub simulation_failures: DashMap<Pubkey, u32>,
+    pub is_locked: AtomicBool,
 }
 
 impl TxExecutor {
@@ -56,35 +60,31 @@ impl TxExecutor {
             runtime,
             tpu_client,
             simulation_failures: DashMap::new(),
+            is_locked: AtomicBool::new(false),
         }
     }
 
     pub fn execute_txs(self: Arc<Self>, slot: u64) -> PluginResult<()> {
         self.spawn(|this| async move {
-            // Get this worker's position in the delegate pool.
-            let worker_pubkey = Worker::pubkey(this.config.worker_id);
-            let pool_position = this
-                .client
-                .get::<Pool>(&Pool::pubkey(0))
-                .map(|pool| {
-                    let workers = &mut pool.workers.clone();
-                    PoolPosition {
-                        current_position: pool
-                            .workers
-                            .iter()
-                            .position(|k| k.eq(&worker_pubkey))
-                            .map(|i| i as u64),
-                        workers: workers.make_contiguous().to_vec().clone(),
-                    }
-                })
-                .unwrap();
+            // Lock until work is done.
+            if this
+                .clone()
+                .is_locked
+                .load(std::sync::atomic::Ordering::Relaxed)
+            {
+                info!("Locked...");
+                return Ok(());
+            }
+            info!("Locking...");
+            this.clone()
+                .is_locked
+                .store(true, std::sync::atomic::Ordering::Relaxed);
 
             // Drop threads that cross the simulation failure threshold.
             this.clone()
                 .simulation_failures
                 .retain(|thread_pubkey, failures| {
                     if *failures >= MAX_THREAD_SIMULATION_FAILURES {
-                        // this.observers.thread.drop_thread(*thread_pubkey);
                         this.observers
                             .thread
                             .executable_threads
@@ -100,17 +100,37 @@ impl TxExecutor {
                 .message_history
                 .retain(|_msg_hash, msg_slot| *msg_slot >= slot - MESSAGE_DEDUPE_PERIOD);
 
-            // Rotate into the worker pool.
-            this.clone()
-                .execute_pool_rotate_txs(slot, pool_position.clone())
-                .await
-                .ok();
+            // Get this worker's position in the delegate pool.
+            let worker_pubkey = Worker::pubkey(this.config.worker_id);
+            if let Ok(pool_position) = this.client.get::<Pool>(&Pool::pubkey(0)).map(|pool| {
+                let workers = &mut pool.workers.clone();
+                PoolPosition {
+                    current_position: pool
+                        .workers
+                        .iter()
+                        .position(|k| k.eq(&worker_pubkey))
+                        .map(|i| i as u64),
+                    workers: workers.make_contiguous().to_vec().clone(),
+                }
+            }) {
+                // Rotate into the worker pool.
+                this.clone()
+                    .execute_pool_rotate_txs(slot, pool_position.clone())
+                    .await
+                    .ok();
 
-            // Execute thread transactions.
+                // Execute thread transactions.
+                this.clone()
+                    .execute_thread_exec_txs(slot, pool_position)
+                    .await
+                    .ok();
+            }
+
+            // Release the lock.
+            info!("Unlocking...");
             this.clone()
-                .execute_thread_exec_txs(slot, pool_position)
-                .await
-                .ok();
+                .is_locked
+                .store(false, std::sync::atomic::Ordering::Relaxed);
 
             Ok(())
         })
@@ -193,6 +213,7 @@ impl TxExecutor {
                 self.clone().simulation_failures.remove(&thread_pubkey);
                 self.clone().execute_tx(slot, &tx).map_err(|err| err).ok();
             });
+
         Ok(())
     }
 


### PR DESCRIPTION
Developers have been creating a lot of threads recently. Both mainnet and devnet are suffering outages and leader nodes show 500+ threads in the executable threads set. Most of these threads are throwing simulation errors yet are not getting purged from the executable threads list. Valid threads appear to be getting starved and have not been executed in hours.

I suspect what's happening is that with this many threads the work that needs to be done per slot takes longer than the duration allocated to each slot. So work is piling up and it seems eventually we either hit some tokio limitation or cause a panic in our dashmap access patterns. 

This PR is a hotfix. It uses an AtomicBool to introduce a lock around the transaction executor logic. If an executor is currently doing work, it returns early and doesn't attempt to simulate or queue up any new transactions. I've deployed this to devnet watched it help the network recover. Logs from nodes look much healthier now with 0 threads sitting around in the executable threads list. Scheduled threads are now firing according to their trigger schedules. 

I'm deploy to our mainnet nodes to mitigate the outage there. 