### PR TITLE
Increase compute unit buffer to 1000

### DIFF
--- a/plugin/src/builders/thread_exec.rs
+++ b/plugin/src/builders/thread_exec.rs
@@ -27,7 +27,7 @@ static TRANSACTION_MESSAGE_SIZE_LIMIT: usize = 1_232;
 static TRANSACTION_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
 
 /// The buffer amount to add to transactions' compute units in case on-chain PDA derivations take more CUs than used in simulation.
-static TRANSACTION_COMPUTE_UNIT_BUFFER: u32 = 100;
+static TRANSACTION_COMPUTE_UNIT_BUFFER: u32 = 1000;
 
 pub async fn build_thread_exec_tx(
     client: Arc<RpcClient>,


### PR DESCRIPTION
We're still hitting compute unit limits due to variable cost PDA derivations. 