### PR TITLE
Change u64 to usize

### DIFF
--- a/programs/thread/src/instructions/thread_exec.rs
+++ b/programs/thread/src/instructions/thread_exec.rs
@@ -154,7 +154,7 @@ pub fn handler(ctx: Context<ThreadExec>) -> Result<()> {
     // If there is no dynamic next instruction, get the next instruction from the instruction set.
     let mut exec_index = thread.exec_context.unwrap().exec_index;
     if next_instruction.is_none() {
-        if let Some(ix) = thread.instructions.get(exec_index + 1) {
+        if let Some(ix) = thread.instructions.get((exec_index + 1) as usize) {
             next_instruction = Some(ix.clone());
             exec_index = exec_index + 1;
         }

--- a/programs/thread/src/instructions/thread_kickoff.rs
+++ b/programs/thread/src/instructions/thread_kickoff.rs
@@ -61,7 +61,8 @@ pub fn handler(ctx: Context<ThreadKickoff>) -> Result<()> {
                     // Begin computing the data hash of this account.
                     let mut hasher = DefaultHasher::new();
                     let data = &account_info.try_borrow_data().unwrap();
-                    let range_end = offset.checked_add(size).unwrap();
+                    let offset = offset as usize;
+                    let range_end = offset.checked_add(size as usize).unwrap() as usize;
                     if data.len().gt(&range_end) {
                         data[offset..range_end].hash(&mut hasher);
                     } else {

--- a/programs/thread/src/state/thread.rs
+++ b/programs/thread/src/state/thread.rs
@@ -67,7 +67,7 @@ impl ThreadAccount for Account<'_, Thread> {
     fn pubkey(&self) -> Pubkey {
         Thread::pubkey(self.authority, self.id.clone())
     }
-    
+
     fn realloc(&mut self) -> Result<()> {
         // Realloc memory for the thread account
         let data_len = 8 + self.try_to_vec()?.len();
@@ -80,7 +80,7 @@ impl ThreadAccount for Account<'_, Thread> {
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ExecContext {
     /// Index of the next instruction to be executed.
-    pub exec_index: usize,
+    pub exec_index: u64,
 
     /// Number of execs since the last tx reimbursement.
     pub execs_since_reimbursement: u64,
@@ -103,9 +103,9 @@ pub enum Trigger {
         /// The address of the account to monitor.
         address: Pubkey,
         /// The byte offset of the account data to monitor.
-        offset: usize,
+        offset: u64,
         /// The size of the byte slice to monitor (must be less than 1kb)
-        size: usize,
+        size: u64,
     },
 
     /// Allows a thread to be kicked off according to a one-time or recurring schedule.


### PR DESCRIPTION
`usize` is dependent on machine. Because of this, Anchor typescript doesn't support `usize` in IDLs.