### PR TITLE
Allow threads to close themselves

### DIFF
--- a/plugin/src/versioned_thread.rs
+++ b/plugin/src/versioned_thread.rs
@@ -4,8 +4,8 @@ use anchor_lang::{
 };
 use clockwork_thread_program_v1::state::Thread as ThreadV1;
 use clockwork_thread_program_v2::state::{
-    SerializableAccount, Thread as ThreadV2, ClockData, ExecContext, SerializableInstruction, Trigger,
-    TriggerContext,
+    ClockData, ExecContext, SerializableAccount, SerializableInstruction, Thread as ThreadV2,
+    Trigger, TriggerContext,
 };
 
 #[derive(Clone, Debug)]

--- a/programs/thread/src/instructions/thread_delete.rs
+++ b/programs/thread/src/instructions/thread_delete.rs
@@ -20,7 +20,7 @@ pub struct ThreadDelete<'info> {
             thread.id.as_slice(),
         ],
         bump = thread.bump,
-        has_one = authority,
+        constraint = thread.authority.eq(&authority.key()) || thread.key().eq(&authority.key()),
         close = close_to
     )]
     pub thread: Account<'info, Thread>,

--- a/programs/thread/src/instructions/thread_delete.rs
+++ b/programs/thread/src/instructions/thread_delete.rs
@@ -4,7 +4,9 @@ use {crate::state::*, anchor_lang::prelude::*};
 #[derive(Accounts)]
 pub struct ThreadDelete<'info> {
     /// The authority (owner) of the thread.
-    #[account()]
+    #[account(
+        constraint = authority.key().eq(&thread.authority) || authority.key().eq(&thread.key())
+    )]
     pub authority: Signer<'info>,
 
     /// The address to return the data rent lamports to.
@@ -20,7 +22,6 @@ pub struct ThreadDelete<'info> {
             thread.id.as_slice(),
         ],
         bump = thread.bump,
-        constraint = thread.authority.eq(&authority.key()) || thread.key().eq(&authority.key()),
         close = close_to
     )]
     pub thread: Account<'info, Thread>,


### PR DESCRIPTION
This constraint update should allow threads to use the `dynamic_instruction` to close themselves when they are done without violating CPI reentrancy constraints. 