### PR TITLE
Add support for slot-based triggers

### DIFF
--- a/programs/thread/src/instructions/thread_kickoff.rs
+++ b/programs/thread/src/instructions/thread_kickoff.rs
@@ -149,7 +149,16 @@ pub fn handler(ctx: Context<ThreadKickoff>) -> Result<()> {
                 trigger_context: TriggerContext::Now,
             });
         }
-        Trigger::Slot { slot } => {}
+        Trigger::Slot { slot } => {
+            require!(clock.slot.ge(&slot), ClockworkError::TriggerNotActive);
+            thread.exec_context = Some(ExecContext {
+                exec_index: 0,
+                execs_since_reimbursement: 0,
+                execs_since_slot: 0,
+                last_exec_at: clock.slot,
+                trigger_context: TriggerContext::Slot { started_at: slot },
+            });
+        }
     }
 
     // If we make it here, the trigger is active. Update the next instruction and be done.

--- a/programs/thread/src/instructions/thread_kickoff.rs
+++ b/programs/thread/src/instructions/thread_kickoff.rs
@@ -149,6 +149,7 @@ pub fn handler(ctx: Context<ThreadKickoff>) -> Result<()> {
                 trigger_context: TriggerContext::Now,
             });
         }
+        Trigger::Slot { slot } => {}
     }
 
     // If we make it here, the trigger is active. Update the next instruction and be done.

--- a/programs/thread/src/state/thread.rs
+++ b/programs/thread/src/state/thread.rs
@@ -111,6 +111,12 @@ pub enum TriggerContext {
 
     /// The trigger context for threads with a "now" trigger.
     Now,
+
+    /// The trigger context for threads with a "slot" trigger.
+    Slot {
+        /// The threshold slot the schedule was waiting for.
+        started_at: u64,
+    },
 }
 
 /// The properties of threads which are updatable.

--- a/utils/src/thread.rs
+++ b/utils/src/thread.rs
@@ -68,6 +68,9 @@ pub enum Trigger {
 
     /// Allows an thread to be kicked off as soon as it's created.
     Now,
+
+    /// Allows a thread to be kicked off according to a slot.
+    Slot { slot: u64 },
 }
 
 /// A response value target programs can return to update the thread.


### PR DESCRIPTION
This is a very simple trigger condition, allowing a user to set a `slot` number that they want a thread to be triggered at. This does not support recurring schedules, but users can return a new `trigger` in the `ThreadResponse` to effectively implement a recurring, slot-based schedule. 

A future PR will add support for epoch-based triggers. 