### PR TITLE
Add close_to property on ThreadResponse

### DIFF
--- a/programs/network/src/jobs/delete_snapshot/job.rs
+++ b/programs/network/src/jobs/delete_snapshot/job.rs
@@ -3,7 +3,6 @@ use clockwork_utils::thread::ThreadResponse;
 
 use crate::state::*;
 
-
 #[derive(Accounts)]
 pub struct DeleteSnapshotJob<'info> {
     #[account(address = Config::pubkey())]
@@ -39,6 +38,7 @@ pub fn handler(ctx: Context<DeleteSnapshotJob>) -> Result<ThreadResponse> {
             }
             .into(),
         ),
+        close_to: None,
         trigger: None,
     })
 }

--- a/programs/network/src/jobs/delete_snapshot/process_entry.rs
+++ b/programs/network/src/jobs/delete_snapshot/process_entry.rs
@@ -132,5 +132,5 @@ pub fn handler(ctx: Context<DeleteSnapshotProcessEntry>) -> Result<ThreadRespons
         None
     };
 
-    Ok( ThreadResponse { dynamic_instruction, trigger: None } )
+    Ok( ThreadResponse { dynamic_instruction, close_to: None, trigger: None } )
 }

--- a/programs/network/src/jobs/delete_snapshot/process_snapshot.rs
+++ b/programs/network/src/jobs/delete_snapshot/process_snapshot.rs
@@ -71,5 +71,5 @@ pub fn handler(ctx: Context<DeleteSnapshotProcessSnapshot>) -> Result<ThreadResp
         None
     };
 
-    Ok(ThreadResponse { dynamic_instruction, trigger: None })
+    Ok(ThreadResponse { dynamic_instruction, close_to:None, trigger: None })
 }

--- a/programs/network/src/jobs/distribute_fees/job.rs
+++ b/programs/network/src/jobs/distribute_fees/job.rs
@@ -44,6 +44,7 @@ pub fn handler(ctx: Context<DistributeFeesJob>) -> Result<ThreadResponse> {
             }
             .into(),
         ),
+        close_to: None,
         trigger: None,
     })
 }

--- a/programs/network/src/jobs/distribute_fees/process_entry.rs
+++ b/programs/network/src/jobs/distribute_fees/process_entry.rs
@@ -168,6 +168,7 @@ pub fn handler(ctx: Context<DistributeFeesProcessEntry>) -> Result<ThreadRespons
 
     Ok(ThreadResponse {
         dynamic_instruction,
+        close_to: None,
         trigger: None,
     })
 }

--- a/programs/network/src/jobs/distribute_fees/process_frame.rs
+++ b/programs/network/src/jobs/distribute_fees/process_frame.rs
@@ -143,6 +143,7 @@ pub fn handler(ctx: Context<DistributeFeesProcessFrame>) -> Result<ThreadRespons
 
     Ok(ThreadResponse {
         dynamic_instruction,
+        close_to: None,
         trigger: None,
     })
 }

--- a/programs/network/src/jobs/distribute_fees/process_snapshot.rs
+++ b/programs/network/src/jobs/distribute_fees/process_snapshot.rs
@@ -67,6 +67,7 @@ pub fn handler(ctx: Context<DistributeFeesProcessSnapshot>) -> Result<ThreadResp
         } else {
             None
         },
+        close_to: None,
         trigger: None,
     })
 }

--- a/programs/network/src/jobs/increment_epoch/job.rs
+++ b/programs/network/src/jobs/increment_epoch/job.rs
@@ -23,8 +23,9 @@ pub fn handler(ctx: Context<EpochCutover>) -> Result<ThreadResponse> {
     let registry = &mut ctx.accounts.registry;
     registry.current_epoch = registry.current_epoch.checked_add(1).unwrap();
     registry.locked = false;
-    
+
     Ok(ThreadResponse {
+        close_to: None,
         dynamic_instruction: None,
         trigger: None,
     })

--- a/programs/network/src/jobs/process_unstakes/job.rs
+++ b/programs/network/src/jobs/process_unstakes/job.rs
@@ -44,6 +44,7 @@ pub fn handler(ctx: Context<ProcessUnstakesJob>) -> Result<ThreadResponse> {
         } else {
             None
         },
+        close_to: None,
         trigger: None,
     })
 }

--- a/programs/network/src/jobs/process_unstakes/unstake_process.rs
+++ b/programs/network/src/jobs/process_unstakes/unstake_process.rs
@@ -155,6 +155,7 @@ pub fn handler(ctx: Context<UnstakeProcess>) -> Result<ThreadResponse> {
 
     Ok(ThreadResponse {
         dynamic_instruction,
+        close_to: None,
         trigger: None,
     })
 }

--- a/programs/network/src/jobs/stake_delegations/job.rs
+++ b/programs/network/src/jobs/stake_delegations/job.rs
@@ -42,6 +42,7 @@ pub fn handler(ctx: Context<StakeDelegationsJob>) -> Result<ThreadResponse> {
         } else {
             None
         },
+        close_to: None,
         trigger: None,
     })
 }

--- a/programs/network/src/jobs/stake_delegations/process_delegation.rs
+++ b/programs/network/src/jobs/stake_delegations/process_delegation.rs
@@ -147,6 +147,7 @@ pub fn handler(ctx: Context<StakeDelegationsProcessDelegation>) -> Result<Thread
 
     Ok(ThreadResponse {
         dynamic_instruction,
+        close_to: None,
         trigger: None,
     })
 }

--- a/programs/network/src/jobs/stake_delegations/process_worker.rs
+++ b/programs/network/src/jobs/stake_delegations/process_worker.rs
@@ -81,6 +81,7 @@ pub fn handler(ctx: Context<StakeDelegationsProcessWorker>) -> Result<ThreadResp
 
     Ok(ThreadResponse {
         dynamic_instruction,
+        close_to: None,
         trigger: None,
     })
 }

--- a/programs/network/src/jobs/take_snapshot/create_frame.rs
+++ b/programs/network/src/jobs/take_snapshot/create_frame.rs
@@ -149,6 +149,7 @@ pub fn handler(ctx: Context<TakeSnapshotCreateFrame>) -> Result<ThreadResponse> 
 
     Ok(ThreadResponse {
         dynamic_instruction,
+        close_to: None,
         trigger: None,
     })
 }

--- a/programs/network/src/jobs/take_snapshot/create_snapshot.rs
+++ b/programs/network/src/jobs/take_snapshot/create_snapshot.rs
@@ -81,6 +81,7 @@ pub fn handler(ctx: Context<TakeSnapshotCreateSnapshot>) -> Result<ThreadRespons
         } else {
             None
         },
+        close_to: None,
         trigger: None,
     })
 }

--- a/programs/network/src/jobs/take_snapshot/job.rs
+++ b/programs/network/src/jobs/take_snapshot/job.rs
@@ -45,6 +45,7 @@ pub fn handler(ctx: Context<TakeSnapshotJob>) -> Result<ThreadResponse> {
             }
             .into(),
         ),
+        close_to: None,
         trigger: None,
     })
 }

--- a/programs/thread/src/instructions/thread_delete.rs
+++ b/programs/thread/src/instructions/thread_delete.rs
@@ -22,11 +22,25 @@ pub struct ThreadDelete<'info> {
             thread.id.as_slice(),
         ],
         bump = thread.bump,
-        close = close_to
     )]
     pub thread: Account<'info, Thread>,
 }
 
-pub fn handler(_ctx: Context<ThreadDelete>) -> Result<()> {
+pub fn handler(ctx: Context<ThreadDelete>) -> Result<()> {
+    let thread = &ctx.accounts.thread;
+    let close_to = &ctx.accounts.close_to;
+
+    let thread_lamports = thread.to_account_info().lamports();
+    **thread.to_account_info().try_borrow_mut_lamports()? = thread
+        .to_account_info()
+        .lamports()
+        .checked_sub(thread_lamports)
+        .unwrap();
+    **close_to.to_account_info().try_borrow_mut_lamports()? = close_to
+        .to_account_info()
+        .lamports()
+        .checked_add(thread_lamports)
+        .unwrap();
+
     Ok(())
 }

--- a/utils/src/thread.rs
+++ b/utils/src/thread.rs
@@ -79,6 +79,9 @@ pub enum Trigger {
 /// A response value target programs can return to update the thread.
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Debug)]
 pub struct ThreadResponse {
+    /// If set, the thread will automatically close and return lamports to the provided address.
+    /// If dynamic_instruction is also set, it will take precidence and the thread will not be closed.
+    pub close_to: Option<Pubkey>,
     /// A dynamic instruction to execute next.
     pub dynamic_instruction: Option<SerializableInstruction>,
     /// Value to update the thread trigger to.
@@ -88,6 +91,7 @@ pub struct ThreadResponse {
 impl Default for ThreadResponse {
     fn default() -> Self {
         return Self {
+            close_to: None,
             dynamic_instruction: None,
             trigger: None,
         };


### PR DESCRIPTION
This is a convenience interface to easily close thread accounts. With the new `ThreadReponse` schema, dynamic instructions will be limited to up to 28 accounts. Will reach out to Solana team about expanding the return data buffer to 2048 bytes. 