### PR TITLE
Introduce Pyth trigger types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,6 +1155,7 @@ dependencies = [
  "anchor-lang",
  "chrono",
  "clockwork-thread-program",
+ "clockwork-utils",
  "nom",
  "once_cell",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,6 +1113,7 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "clockwork-utils",
+ "winnow",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,6 +1169,7 @@ dependencies = [
  "clockwork-network-program",
  "clockwork-thread-program-v1",
  "clockwork-utils",
+ "pyth-sdk-solana",
  "static-pubkey",
  "version",
 ]
@@ -1224,6 +1225,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.17",
  "prost",
+ "pyth-sdk-solana",
  "reqwest",
  "rustc_version",
  "serde",
@@ -1236,6 +1238,7 @@ dependencies = [
  "solana-program",
  "solana-sdk",
  "solana-transaction-status",
+ "static-pubkey",
  "thiserror",
  "tokio",
 ]
@@ -1653,6 +1656,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
+
+[[package]]
 name = "eager"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,6 +2076,15 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "histogram"
@@ -3110,6 +3128,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyth-sdk"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bf2540203ca3c7a5712fdb8b5897534b7f6a0b6e7b0923ff00466c5f9efcb3"
+dependencies = [
+ "borsh",
+ "borsh-derive",
+ "hex",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "pyth-sdk-solana"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bc0e0ab39d0543220dcba7c248161aab70e25916b2c1585057abc0856ff4e0c"
+dependencies = [
+ "borsh",
+ "borsh-derive",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "pyth-sdk",
+ "serde",
+ "solana-program",
+ "thiserror",
+]
+
+[[package]]
 name = "qstring"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3534,6 +3582,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
+dependencies = [
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "serde_derive_internals",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3611,6 +3683,17 @@ dependencies = [
  "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 2.0.14",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+dependencies = [
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,7 +1155,6 @@ dependencies = [
  "anchor-lang",
  "chrono",
  "clockwork-thread-program",
- "clockwork-utils",
  "nom",
  "once_cell",
 ]

--- a/app/src/components/thread_info_table.rs
+++ b/app/src/components/thread_info_table.rs
@@ -29,6 +29,7 @@ pub fn ThreadInfoTable(cx: Scope<ThreadInfoTableProps>) -> Element {
         Trigger::Slot { slot } => slot.to_string(),
         Trigger::Epoch { epoch } => epoch.to_string(),
         Trigger::Timestamp { unix_ts } => unix_ts.to_string(),
+        Trigger::Pyth { price_feed: _, equality: _, limit: _ } => "Pyth".to_string(),
     };
 
     let id = String::from_utf8(thread.id()).unwrap();

--- a/app/src/components/threads_table.rs
+++ b/app/src/components/threads_table.rs
@@ -295,6 +295,7 @@ fn Row(cx: Scope<RowProps>) -> Element {
         Trigger::Slot { slot } => slot.to_string(),
         Trigger::Epoch { epoch } => epoch.to_string(),
         Trigger::Timestamp { unix_ts } => unix_ts.to_string(),
+        Trigger::Pyth { price_feed: _, equality: _, limit: _ } => "Pyth".to_string(),
     };
 
     enum Status {

--- a/app/src/components/threads_table.rs
+++ b/app/src/components/threads_table.rs
@@ -418,6 +418,7 @@ fn Row(cx: Scope<RowProps>) -> Element {
             Trigger::Slot { slot: _ } => Status::Unknown,
             Trigger::Epoch { epoch: _ } => Status::Unknown,
             Trigger::Timestamp { unix_ts: _ } => Status::Unknown,
+            Trigger::Pyth { price_feed: _, equality: _, limit: _ } => Status::Unknown,
         }
     };
     let status_class = match health {

--- a/app/src/context/client.rs
+++ b/app/src/context/client.rs
@@ -280,6 +280,15 @@ fn build_kickoff_ix(
             is_signer: false,
             is_writable: false,
         }),
+        Trigger::Pyth {
+            price_feed,
+            equality: _,
+            limit: _,
+        } => kickoff_ix.accounts.push(AccountMeta {
+            pubkey: price_feed,
+            is_signer: false,
+            is_writable: false,
+        }),
         _ => {}
     }
 

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "clockwork_plugin"
 version = "2.0.15"
 # this needs to match whatever solana uses!
-rust-version = "1.65.0"
+rust-version = "1.60.0"
 edition = "2021"
 description = "Clockwork plugin for Solana validators"
 license = "AGPL-3.0-or-later"

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "clockwork_plugin"
 version = "2.0.15"
 # this needs to match whatever solana uses!
-rust-version = "1.60.0"
+rust-version = "1.65.0"
 edition = "2021"
 description = "Clockwork plugin for Solana validators"
 license = "AGPL-3.0-or-later"
@@ -34,6 +34,7 @@ clockwork-utils = { path = "../utils", version = "2.0.15" }
 lazy_static = "1.4.0"
 log = "0.4"
 prost = "0.10.0"
+pyth-sdk-solana = "0.7.1"
 reqwest = "0.11.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -48,6 +49,7 @@ solana-transaction-status = "=1.14.16"
 thiserror = "1.0.30"
 tokio = "1.18.4"
 futures = "0.3.26"
+static-pubkey = "1.0.3"
 
 [build-dependencies]
 cargo_toml = "0.13.0"

--- a/plugin/build.rs
+++ b/plugin/build.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 fn main() {
     let rustc_v = version().unwrap().to_string();
-    let expected_v = "1.65.0".to_string();
+    let expected_v = "1.60.0".to_string();
 
     // Check for a minimum version
     if rustc_v != expected_v {

--- a/plugin/build.rs
+++ b/plugin/build.rs
@@ -1,23 +1,21 @@
-use rustc_version::{version};
 use cargo_toml::{Dependency, Manifest};
+use rustc_version::version;
 use std::process::Command;
 
 fn main() {
     let rustc_v = version().unwrap().to_string();
-    let expected_v = "1.60.0".to_string();
+    let expected_v = "1.65.0".to_string();
 
     // Check for a minimum version
     if rustc_v != expected_v {
-        println!("cargo:warning=trying to compile with rustc {}, we should be using {}",
-                 version().unwrap().to_string(),
-                 expected_v,
+        println!(
+            "cargo:warning=trying to compile with rustc {}, we should be using {}",
+            version().unwrap().to_string(),
+            expected_v,
         );
         std::process::exit(1);
     }
-    println!(
-        "cargo:rustc-env=RUSTC_VERSION={:#?}",
-        rustc_v,
-    );
+    println!("cargo:rustc-env=RUSTC_VERSION={:#?}", rustc_v,);
 
     let output = Command::new("git")
         .args(&["rev-parse", "HEAD"])

--- a/plugin/src/builders/thread_exec.rs
+++ b/plugin/src/builders/thread_exec.rs
@@ -254,6 +254,15 @@ fn build_kickoff_ix(
             is_signer: false,
             is_writable: false,
         }),
+        Trigger::Pyth {
+            price_feed,
+            equality: _,
+            limit: _,
+        } => kickoff_ix.accounts.push(AccountMeta {
+            pubkey: price_feed,
+            is_signer: false,
+            is_writable: false,
+        }),
         _ => {}
     }
 

--- a/plugin/src/events.rs
+++ b/plugin/src/events.rs
@@ -13,7 +13,7 @@ use static_pubkey::static_pubkey;
 static PYTH_ORACLE_PROGRAM_ID_MAINNET: Pubkey =
     static_pubkey!("GjphYQcbP1m3FuDyCTUJf2mUMxKPE3j6feWU1rxvC7Ps");
 static PYTH_ORACLE_PROGRAM_ID_DEVNET: Pubkey =
-    static_pubkey!("FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH");
+    static_pubkey!("gSbePebfvPy7tRqimPoVecS2UsBvYv46ynrzWocc92s");
 
 #[derive(Debug)]
 pub enum AccountUpdateEvent {
@@ -77,6 +77,7 @@ impl TryFrom<&mut ReplicaAccountInfo<'_>> for AccountUpdateEvent {
         if owner_pubkey.eq(&PYTH_ORACLE_PROGRAM_ID_MAINNET)
             || owner_pubkey.eq(&PYTH_ORACLE_PROGRAM_ID_DEVNET)
         {
+            log::info!("Observed pyth oracle change");
             let data = &mut account_info.data.to_vec();
             let acc_info = AccountInfo::new(
                 &account_pubkey,

--- a/plugin/src/events.rs
+++ b/plugin/src/events.rs
@@ -77,7 +77,6 @@ impl TryFrom<&mut ReplicaAccountInfo<'_>> for AccountUpdateEvent {
         if owner_pubkey.eq(&PYTH_ORACLE_PROGRAM_ID_MAINNET)
             || owner_pubkey.eq(&PYTH_ORACLE_PROGRAM_ID_DEVNET)
         {
-            log::info!("Observed pyth oracle change");
             let data = &mut account_info.data.to_vec();
             let acc_info = AccountInfo::new(
                 &account_pubkey,

--- a/plugin/src/events.rs
+++ b/plugin/src/events.rs
@@ -1,17 +1,25 @@
-use anchor_lang::{AccountDeserialize, Discriminator};
+use anchor_lang::{prelude::AccountInfo, AccountDeserialize, Discriminator};
 use bincode::deserialize;
 use clockwork_client::webhook::state::Webhook;
 use clockwork_thread_program::state::{Thread as ThreadV2, VersionedThread};
 use clockwork_thread_program_v1::state::Thread as ThreadV1;
+use pyth_sdk_solana::load_price_feed_from_account_info;
 use solana_geyser_plugin_interface::geyser_plugin_interface::{
     GeyserPluginError, ReplicaAccountInfo,
 };
 use solana_program::{clock::Clock, pubkey::Pubkey, sysvar};
+use static_pubkey::static_pubkey;
+
+static PYTH_ORACLE_PROGRAM_ID_MAINNET: Pubkey =
+    static_pubkey!("GjphYQcbP1m3FuDyCTUJf2mUMxKPE3j6feWU1rxvC7Ps");
+static PYTH_ORACLE_PROGRAM_ID_DEVNET: Pubkey =
+    static_pubkey!("FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH");
 
 #[derive(Debug)]
 pub enum AccountUpdateEvent {
     Clock { clock: Clock },
     Thread { thread: VersionedThread },
+    // Price { price: Price },
     Webhook { webhook: Webhook },
 }
 
@@ -63,6 +71,31 @@ impl TryFrom<&mut ReplicaAccountInfo<'_>> for AccountUpdateEvent {
                     ),
                 });
             }
+        }
+
+        // If the account belongs to Pyth, attempt to parse it.
+        // if owner_pubkey.eq()
+        if owner_pubkey.eq(&PYTH_ORACLE_PROGRAM_ID_MAINNET)
+            || owner_pubkey.eq(&PYTH_ORACLE_PROGRAM_ID_DEVNET)
+        {
+            let mut data = account_info.data;
+            let acc_info = AccountInfo::new(
+                &account_pubkey,
+                false,
+                false,
+                &mut account_info.lamports,
+                data,
+                &owner_pubkey,
+                account_info.executable,
+                account_info.rent_epoch,
+            );
+            let price = load_price_feed_from_account_info(&acc_info).map_err(|_| {
+                GeyserPluginError::AccountsUpdateError {
+                    msg: "Failed to parse Pyth price account".into(),
+                }
+            })?;
+
+            todo!("Parse the pyth account")
         }
 
         // If the account belongs to the webhook program, parse in

--- a/plugin/src/observers/thread.rs
+++ b/plugin/src/observers/thread.rs
@@ -180,9 +180,7 @@ impl ThreadObserver {
     ) -> PluginResult<()> {
         let r_pyth_threads = self.pyth_threads.read().await;
         if let Some(pyth_threads) = r_pyth_threads.get(&account_pubkey) {
-            log::info!("Pyth threads {:?} watching price feed {:?}", pyth_threads.len(), account_pubkey);
             for pyth_thread in pyth_threads {
-                log::info!("comparing equality: {:?} {:?} {:?}", price_feed.get_price_unchecked().price, pyth_thread.equality, pyth_thread.limit);
                 match pyth_thread.equality {
                     Equality::GreaterThanOrEqual => {
                         if price_feed
@@ -224,7 +222,7 @@ impl ThreadObserver {
             return Ok(());
         }
 
-        info!("indexing thread: {:?} slot: {}", thread_pubkey, slot);
+        info!("Indexing thread: {:?} slot: {}", thread_pubkey, slot);
         if thread.next_instruction().is_some() {
             // If the thread has a next instruction, index it as executable.
             let mut w_now_threads = self.now_threads.write().await;

--- a/plugin/src/observers/thread.rs
+++ b/plugin/src/observers/thread.rs
@@ -188,9 +188,9 @@ impl ThreadObserver {
                             .price
                             .ge(&pyth_thread.limit)
                         {
-                            let mut w_updated_accounts = self.updated_accounts.write().await;
-                            w_updated_accounts.insert(account_pubkey);
-                            drop(w_updated_accounts);
+                            let mut w_now_threads = self.now_threads.write().await;
+                            w_now_threads.insert(account_pubkey);
+                            drop(w_now_threads);
                         }
                     }
                     Equality::LessThanOrEqual => {
@@ -199,9 +199,9 @@ impl ThreadObserver {
                             .price
                             .le(&pyth_thread.limit)
                         {
-                            let mut w_updated_accounts = self.updated_accounts.write().await;
-                            w_updated_accounts.insert(account_pubkey);
-                            drop(w_updated_accounts);
+                            let mut w_now_threads = self.now_threads.write().await;
+                            w_now_threads.insert(account_pubkey);
+                            drop(w_now_threads);
                         }
                     }
                 }

--- a/plugin/src/observers/thread.rs
+++ b/plugin/src/observers/thread.rs
@@ -191,7 +191,7 @@ impl ThreadObserver {
                             .ge(&pyth_thread.limit)
                         {
                             let mut w_now_threads = self.now_threads.write().await;
-                            w_now_threads.insert(account_pubkey);
+                            w_now_threads.insert(pyth_thread.thread_pubkey);
                             drop(w_now_threads);
                         }
                     }
@@ -202,7 +202,7 @@ impl ThreadObserver {
                             .le(&pyth_thread.limit)
                         {
                             let mut w_now_threads = self.now_threads.write().await;
-                            w_now_threads.insert(account_pubkey);
+                            w_now_threads.insert(pyth_thread.thread_pubkey);
                             drop(w_now_threads);
                         }
                     }

--- a/plugin/src/observers/thread.rs
+++ b/plugin/src/observers/thread.rs
@@ -180,7 +180,9 @@ impl ThreadObserver {
     ) -> PluginResult<()> {
         let r_pyth_threads = self.pyth_threads.read().await;
         if let Some(pyth_threads) = r_pyth_threads.get(&account_pubkey) {
+            log::info!("Pyth threads {:?} watching price feed {:?}", pyth_threads.len(), account_pubkey);
             for pyth_thread in pyth_threads {
+                log::info!("comparing equality: {:?} {:?} {:?}", price_feed.get_price_unchecked().price, pyth_thread.equality, pyth_thread.limit);
                 match pyth_thread.equality {
                     Equality::GreaterThanOrEqual => {
                         if price_feed

--- a/plugin/src/plugin.rs
+++ b/plugin/src/plugin.rs
@@ -125,6 +125,7 @@ impl GeyserPlugin for ClockworkPlugin {
                             .ok();
                     }
                     AccountUpdateEvent::PriceFeed { price_feed } => {
+                        log::info!("Got price_feed evenet: {:?}", price_feed);
                         inner
                             .observers
                             .thread

--- a/plugin/src/plugin.rs
+++ b/plugin/src/plugin.rs
@@ -124,6 +124,15 @@ impl GeyserPlugin for ClockworkPlugin {
                             .await
                             .ok();
                     }
+                    AccountUpdateEvent::PriceFeed { price_feed } => {
+                        inner
+                            .observers
+                            .thread
+                            .clone()
+                            .observe_price_feed(account_pubkey, price_feed)
+                            .await
+                            .ok();
+                    }
                 }
             }
             Ok(())

--- a/plugin/src/plugin.rs
+++ b/plugin/src/plugin.rs
@@ -125,7 +125,6 @@ impl GeyserPlugin for ClockworkPlugin {
                             .ok();
                     }
                     AccountUpdateEvent::PriceFeed { price_feed } => {
-                        log::info!("Got price_feed evenet: {:?}", price_feed);
                         inner
                             .observers
                             .thread

--- a/programs/network/Cargo.toml
+++ b/programs/network/Cargo.toml
@@ -25,3 +25,4 @@ default = []
 anchor-lang = "0.27.0"
 anchor-spl = { features = ["mint", "token"], version = "0.27.0" }
 clockwork-utils = { path = "../../utils", version = "2.0.15" }
+winnow = "=0.4.1"

--- a/programs/thread/Cargo.toml
+++ b/programs/thread/Cargo.toml
@@ -28,5 +28,6 @@ clockwork-cron = { path = "../../cron", version = "2.0.15" }
 clockwork-network-program = { path = "../network", features = ["cpi"], version = "2.0.15" }
 clockwork-thread-program-v1 = { path = "v1", version = "1.4.4" }
 clockwork-utils = { path = "../../utils", version = "2.0.15" }
+pyth-sdk-solana = "0.7.1"
 static-pubkey = "1.0.3"
 version = "3.0.0"

--- a/programs/thread/src/state/thread.rs
+++ b/programs/thread/src/state/thread.rs
@@ -129,6 +129,9 @@ pub enum TriggerContext {
         /// The threshold moment the schedule was waiting for.
         started_at: i64,
     },
+
+    /// The trigger context for threads with a "pyth" trigger.
+    Pyth { price: i64 },
 }
 
 /// The properties of threads which are updatable.

--- a/programs/thread/src/state/thread.rs
+++ b/programs/thread/src/state/thread.rs
@@ -1,6 +1,8 @@
 use anchor_lang::{prelude::*, AnchorDeserialize, AnchorSerialize};
 use clockwork_utils::thread::{ClockData, SerializableInstruction, Trigger};
 
+pub use clockwork_utils::thread::Equality;
+
 pub const SEED_THREAD: &[u8] = b"thread";
 
 /// Tracks the current state of a transaction thread on Solana.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.60.0"
-components = [ "rustfmt" ]
+channel = "1.65.0"
+components = [ "rustfmt", "rust-analyzer" ]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.60.0"
 components = [ "rustfmt", "rust-analyzer" ]
 profile = "minimal"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -17,6 +17,7 @@ name = "clockwork_sdk"
 anchor-lang = "0.27.0"
 chrono = { version = "0.4.19", default-features = false, features = ["alloc"] }
 clockwork-thread-program = { path = "../programs/thread", features = ["cpi"], version = "2.0.15" }
+clockwork-utils = { path = "../utils", version = "2.0.15" }
 nom = "~7"
 once_cell = "1.5.2"
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -17,7 +17,6 @@ name = "clockwork_sdk"
 anchor-lang = "0.27.0"
 chrono = { version = "0.4.19", default-features = false, features = ["alloc"] }
 clockwork-thread-program = { path = "../programs/thread", features = ["cpi"], version = "2.0.15" }
-clockwork-utils = { path = "../utils", version = "2.0.15" }
 nom = "~7"
 once_cell = "1.5.2"
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -11,6 +11,7 @@ pub mod state {
 
 pub mod utils {
     pub use clockwork_thread_program::state::PAYER_PUBKEY;
+    pub use clockwork_utils::thread::Equality;
 }
 
 pub mod cpi {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -11,7 +11,7 @@ pub mod state {
 
 pub mod utils {
     pub use clockwork_thread_program::state::PAYER_PUBKEY;
-    pub use clockwork_utils::thread::Equality;
+    pub use clockwork_thread_program::state::Equality;
 }
 
 pub mod cpi {

--- a/utils/src/thread.rs
+++ b/utils/src/thread.rs
@@ -89,7 +89,7 @@ pub enum Trigger {
 
 /// Values for comparing
 #[repr(u8)]
-#[derive(AnchorDeserialize, AnchorSerialize, Clone, Debug, PartialEq)]
+#[derive(AnchorDeserialize, AnchorSerialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Equality {
     GreaterThanOrEqual,
     LessThanOrEqual,

--- a/utils/src/thread.rs
+++ b/utils/src/thread.rs
@@ -71,18 +71,28 @@ pub enum Trigger {
     Now,
 
     /// Allows a thread to be kicked off according to a slot.
-    Slot {
-        slot: u64,
-    },
+    Slot { slot: u64 },
 
     /// Allows a thread to be kicked off according to an epoch number.
-    Epoch {
-        epoch: u64,
-    },
+    Epoch { epoch: u64 },
 
-    Timestamp {
-        unix_ts: i64,
+    /// Allows a thread to be kicked off according to a unix timestamp.
+    Timestamp { unix_ts: i64 },
+
+    /// Allows a thread to be kicked off according to a Pyth price feed movement.
+    Pyth {
+        price_feed: Pubkey,
+        equality: Equality,
+        limit: i64,
     },
+}
+
+/// Values for comparing
+#[repr(u8)]
+#[derive(AnchorDeserialize, AnchorSerialize, Clone, Debug, PartialEq)]
+pub enum Equality {
+    GreaterThanOrEqual,
+    LessThanOrEqual,
 }
 
 /// A response value target programs can return to update the thread.

--- a/utils/src/thread.rs
+++ b/utils/src/thread.rs
@@ -57,7 +57,7 @@ pub enum Trigger {
         size: u64,
     },
 
-    /// Allows an thread to be kicked off according to a one-time or recurring schedule.
+    /// Allows a thread to be kicked off according to a one-time or recurring schedule.
     Cron {
         /// The schedule in cron syntax. Value must be parsable by the `clockwork_cron` package.
         schedule: String,
@@ -67,7 +67,7 @@ pub enum Trigger {
         skippable: bool,
     },
 
-    /// Allows an thread to be kicked off as soon as it's created.
+    /// Allows a thread to be kicked off as soon as it's created.
     Now,
 
     /// Allows a thread to be kicked off according to a slot.
@@ -81,13 +81,16 @@ pub enum Trigger {
 
     /// Allows a thread to be kicked off according to a Pyth price feed movement.
     Pyth {
+        /// The address of the price feed to monitor.
         price_feed: Pubkey,
+        /// The equality operator (gte or lte) used to compare prices. 
         equality: Equality,
+        /// The limit price to compare the Pyth feed to. 
         limit: i64,
     },
 }
 
-/// Values for comparing
+/// Operators for describing how to compare two values to one another.  
 #[repr(u8)]
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Equality {


### PR DESCRIPTION
This PR introduces a new `Pyth` trigger type. This trigger can be useful for creating automations that are dependent on price movements such as Stop-Loss and Take-Profit orders. While developers can use the existing `Account` automation to monitor a price feed, it is very rare that a user wants to submit a transaction for every single price update (this generally happens many times per slot). With the new `Pyth` trigger type, a user can define a triggering condition using a `price_feed`, `equality`, and `limit` parameters. The `equality` operator can be either gte or lte and is used to compare the Pyth feed to the `limit` price. 