### PR TITLE
localnet --dev

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -56,6 +56,7 @@ pub enum CliCommand {
         program_infos: Vec<ProgramInfo>,
         solana_archive: Option<String>,
         clockwork_archive: Option<String>,
+        dev: bool,
     },
 
     // Pool commands
@@ -388,6 +389,11 @@ pub fn app() -> Command<'static> {
                      ")
                     .takes_value(true),
                 )
+                .arg(
+                    Arg::with_name("dev")
+                        .long("dev")
+                        .help("Use development versions of clockwork programs")
+                    )
         )
         .subcommand(
             Command::new("pool")

--- a/cli/src/deps.rs
+++ b/cli/src/deps.rs
@@ -35,6 +35,7 @@ pub fn download_deps(
     force_init: bool,
     solana_archive: Option<String>,
     clockwork_archive: Option<String>,
+    dev: bool,
 ) -> Result<()> {
     let solana_tag = env!("GEYSER_INTERFACE_VERSION").to_owned().to_tag_version();
     let clockwork_tag = crate_version!().to_owned().to_tag_version();
@@ -49,13 +50,16 @@ pub fn download_deps(
         config::SOLANA_DEPS,
         force_init,
     )?;
-    download_and_extract(
-        &active_runtime,
-        &clockwork_archive.unwrap_or(CliConfig::clockwork_release_url(&clockwork_tag)),
-        &active_runtime.join(CliConfig::clockwork_release_archive()),
-        config::CLOCKWORK_DEPS,
-        force_init,
-    )
+    if !dev {
+        download_and_extract(
+            &active_runtime,
+            &clockwork_archive.unwrap_or(CliConfig::clockwork_release_url(&clockwork_tag)),
+            &active_runtime.join(CliConfig::clockwork_release_archive()),
+            config::CLOCKWORK_DEPS,
+            force_init,
+        )?;
+    }
+    Ok(())
 }
 
 fn all_target_files_exist(directory: &Path, target_files: &[&str]) -> bool {

--- a/cli/src/parser.rs
+++ b/cli/src/parser.rs
@@ -88,6 +88,7 @@ fn parse_bpf_command(matches: &ArgMatches) -> Result<CliCommand, CliError> {
         force_init: matches.is_present("force_init"),
         solana_archive: parse_string("solana_archive", matches).ok(),
         clockwork_archive: parse_string("clockwork_archive", matches).ok(),
+        dev: matches.is_present("dev"),
     })
 }
 

--- a/cli/src/processor/localnet.rs
+++ b/cli/src/processor/localnet.rs
@@ -50,7 +50,7 @@ use {
 };
 
 pub fn start(
-    config: &CliConfig,
+    config: &mut CliConfig,
     client: &Client,
     clone_addresses: Vec<Pubkey>,
     network_url: Option<String>,
@@ -58,12 +58,15 @@ pub fn start(
     force_init: bool,
     solana_archive: Option<String>,
     clockwork_archive: Option<String>,
+    dev: bool,
 ) -> Result<(), CliError> {
+    config.dev = dev;
     deps::download_deps(
         &CliConfig::default_runtime_dir(),
         force_init,
         solana_archive,
         clockwork_archive,
+        dev,
     )
     .map_err(|err| CliError::FailedLocalnet(err.to_string()))?;
 

--- a/cli/src/processor/mod.rs
+++ b/cli/src/processor/mod.rs
@@ -36,7 +36,7 @@ pub fn process(matches: &ArgMatches) -> Result<(), CliError> {
         _ => {}
     }
 
-    let config = CliConfig::load();
+    let mut config = CliConfig::load();
 
     // Build the RPC client
     let payer = read_keypair_file(&config.keypair_path)
@@ -80,8 +80,9 @@ pub fn process(matches: &ArgMatches) -> Result<(), CliError> {
             force_init,
             solana_archive,
             clockwork_archive,
+            dev,
         } => localnet::start(
-            &config,
+            &mut config,
             &client,
             clone_addresses,
             network_url,
@@ -89,6 +90,7 @@ pub fn process(matches: &ArgMatches) -> Result<(), CliError> {
             force_init,
             solana_archive,
             clockwork_archive,
+            dev,
         ),
         CliCommand::PoolGet { id } => pool::get(&client, id),
         CliCommand::PoolList {} => pool::list(&client),

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ make:
     ./scripts/build-all.sh .
 
 tarball:
-    ./scripts/create-tarball.sh
+    ./scripts/ci/create-tarball.sh
 
 clean:
     cargo clean
@@ -15,7 +15,6 @@ re: clean
 
 
 # aliases
-
 version:
     cat VERSION
 
@@ -28,13 +27,29 @@ rust-version:
 kill:
     pkill solana-test-validator
 
-
 release-patch:
     gh workflow run bump-release.yaml -F bump=patch
 
-cli:
-    cargo run --bin clockwork
+cli *args:
+    cargo run --bin clockwork {{args}}
 
+localnet *args:
+    cargo run --bin clockwork localnet --dev {{args}}
+
+logs:
+    less test-ledger/validator.log
+
+tlg:
+    tail -f test-ledger/validator.log
+
+watch:
+    cargo watch -c -x "check"
+
+watch-cli:
+    cargo watch -c -x "check --bin clockwork"
+
+
+# links
 pr:
     open https://github.com/clockwork-xyz/clockwork/pulls
 
@@ -43,3 +58,4 @@ actions:
 
 releases:
     open https://github.com/clockwork-xyz/clockwork/releases
+

--- a/justfile
+++ b/justfile
@@ -33,7 +33,7 @@ release-patch:
 cli *args:
     cargo run --bin clockwork {{args}}
 
-localnet *args:
+localnet *args: make
     cargo run --bin clockwork localnet --dev {{args}}
 
 logs:


### PR DESCRIPTION
added new option `clockwork localnet --dev` to run localnet with dev build instead of published release.

Commands:
- `just localnet`
- `cargo run --bin clockwork localnet --dev`