### PR TITLE
[WIP] Make threads the transaction fee payer

### DIFF
--- a/plugin/src/builders/thread_exec.rs
+++ b/plugin/src/builders/thread_exec.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use anchor_lang::{InstructionData, ToAccountMetas};
-use clockwork_thread_program::state::{VersionedThread, Trigger};
 use clockwork_network_program::state::Worker;
+use clockwork_thread_program::state::{Trigger, VersionedThread};
 use clockwork_utils::thread::PAYER_PUBKEY;
 use log::info;
 use solana_account_decoder::UiAccountEncoding;
@@ -73,7 +73,7 @@ pub async fn build_thread_exec_tx(
     let mut successful_ixs: Vec<Instruction> = vec![];
     let mut units_consumed: Option<u64> = None;
     loop {
-        let mut sim_tx = Transaction::new_with_payer(&ixs, Some(&signatory_pubkey));
+        let mut sim_tx = Transaction::new_with_payer(&ixs, Some(&thread_pubkey));
         sim_tx.sign(&[payer], blockhash);
 
         // Exit early if the transaction exceeds the size limit.
@@ -199,7 +199,7 @@ pub async fn build_thread_exec_tx(
     }
 
     // Build and return the signed transaction.
-    let mut tx = Transaction::new_with_payer(&successful_ixs, Some(&signatory_pubkey));
+    let mut tx = Transaction::new_with_payer(&successful_ixs, Some(&thread_pubkey));
     tx.sign(&[payer], blockhash);
     info!(
         "slot: {:?} thread: {:?} sim_duration: {:?} instruction_count: {:?} compute_units: {:?} tx_sig: {:?}",

--- a/programs/thread/src/instructions/thread_exec.rs
+++ b/programs/thread/src/instructions/thread_exec.rs
@@ -178,7 +178,6 @@ pub fn handler(ctx: Context<ThreadExec>) -> Result<()> {
     }
 
     // Update the exec context.
-    let should_reimburse_transaction = clock.slot > thread.exec_context.unwrap().last_exec_at;
     thread.exec_context = Some(ExecContext {
         exec_index,
         execs_since_slot: if clock.slot == thread.exec_context.unwrap().last_exec_at {
@@ -197,13 +196,7 @@ pub fn handler(ctx: Context<ThreadExec>) -> Result<()> {
 
     // Reimbursement signatory for lamports paid during inner ix.
     let signatory_lamports_post = signatory.lamports();
-    let mut signatory_reimbursement =
-        signatory_lamports_pre.saturating_sub(signatory_lamports_post);
-    if should_reimburse_transaction {
-        signatory_reimbursement = signatory_reimbursement
-            .checked_add(TRANSACTION_BASE_FEE_REIMBURSEMENT)
-            .unwrap();
-    }
+    let signatory_reimbursement = signatory_lamports_pre.saturating_sub(signatory_lamports_post);
     if signatory_reimbursement.gt(&0) {
         **thread.to_account_info().try_borrow_mut_lamports()? = thread
             .to_account_info()

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.60.0"
 components = [ "rustfmt", "rust-analyzer" ]
 profile = "minimal"
 targets = [ "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "aarch64-apple-darwin"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.60.0"
+channel = "1.65.0"
 components = [ "rustfmt", "rust-analyzer" ]
 profile = "minimal"
 targets = [ "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "aarch64-apple-darwin"]


### PR DESCRIPTION
This seems to work on localnet. How does this work if the transaction errors? 

If the thread gets charged even for failed transactions, is this a vulnerability? Ie. someone could maliciously drain a thread's balance.

If this is the case, don't we want to force the fee payer to be a worker?