### PR TITLE
Update solana-version ci script

### DIFF
--- a/scripts/ci/solana-version.sh
+++ b/scripts/ci/solana-version.sh
@@ -6,4 +6,4 @@ set -e
 
 cd "$(dirname "$0")/../../plugin"
 
-cargo read-manifest | jq -r '.dependencies[] | select(.name == "solana-geyser-plugin-interface") | .req'
+cargo tree -p solana-geyser-plugin-interface | grep solana-geyser-plugin-interface | awk '{print $2}'


### PR DESCRIPTION
Existing script would print out the semvar version (eg ^1.16) which are not compatible with the install script